### PR TITLE
document support for R programming language

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Based on this, here are the supported languages:
 | Java                  | `*.java` extension. Supports single-line `//` comments and multi-line `/* */` comments    |
 | JavaScript/Typescript | `*.js/*.ts` extension. Supports single-line `//` comments and multi-line `/* */` comments |
 | Python                | `*.py` extension. Supports single-line `#` comments and multi-line `"""` comments         |
+| R                     | `*.R` extension. Supports single-line `//` comments and multi-line `/* */` comments       |
 
 If you don't see your favorite language in this table, but it does use one of the supported comment formats, submit an issue [here](https://github.com/preslavmihaylov/todocheck/issues/new)
 


### PR DESCRIPTION
Support for R (programming language) was done in #6 but not documented in `README.md`