### PR TITLE
Add support for windows without colorful output

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Download the binary for your OS from the [latest release](https://github.com/pre
 Optionally verify the `sha256` checksum:
  * For macos, run `shasum -a 256 <binary>` & verify it's the same as `<binary>.sha256`
  * For linux, run `sha256sum <binary>`
+ * For windows, use [a SHA256 checksum utility](https://kanguru.zendesk.com/hc/en-us/articles/235228027-SHA256-Checksum-Utilities)
  
  Afterwards, verify the shasum is the same as `<binary>.sha256`.
 

--- a/authmanager/authmanager.go
+++ b/authmanager/authmanager.go
@@ -86,8 +86,9 @@ func acquireToken(authCfg *config.Auth, tokenKey string, promptCallback func() (
 // Make token input scriptable, while preserving the hidden prompt behavior for users
 // https://github.com/golang/go/issues/19909#issuecomment-399409958
 func readPassword() ([]byte, error) {
-	if terminal.IsTerminal(syscall.Stdin) {
-		return terminal.ReadPassword(syscall.Stdin)
+	fd := int(syscall.Stdin)
+	if terminal.IsTerminal(fd) {
+		return terminal.ReadPassword(fd)
 	}
 
 	reader := bufio.NewReader(os.Stdin)

--- a/config/auth.go
+++ b/config/auth.go
@@ -1,6 +1,8 @@
 package config
 
-import "github.com/mitchellh/go-homedir"
+import (
+	"github.com/mitchellh/go-homedir"
+)
 
 // AuthType specifies the type of the auth token in todocheck's config
 type AuthType string

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -24,6 +25,8 @@ const (
 	IssueTrackerPivotal              = "PIVOTAL_TRACKER"
 	IssueTrackerRedmine              = "REDMINE"
 )
+
+var windowsAbsolutePathPattern = regexp.MustCompile("^[A-Z]{1}:")
 
 // Local todocheck configuration struct definition
 type Local struct {
@@ -104,5 +107,5 @@ func removeCurrentDirReference(dirs []string) {
 }
 
 func isRelativePath(path string) bool {
-	return path[0] != '/' && path[0] != '~'
+	return path[0] != '/' && path[0] != '~' && !windowsAbsolutePathPattern.MatchString(path)
 }

--- a/release.sh
+++ b/release.sh
@@ -22,6 +22,7 @@ function create_build {
 }
 
 mkdir -p $DIR
+create_build windows amd64 x86_64.exe
 create_build darwin amd64 x86_64
 create_build linux amd64 x86_64
 create_build linux arm64

--- a/traverser/lines/lines.go
+++ b/traverser/lines/lines.go
@@ -104,5 +104,9 @@ func isSupported(supportedExtensions []string, file string) bool {
 }
 
 func isHidden(path string) bool {
-	return len(path) > 1 && path[:2] != "./" && path[:2] != ".." && path[0] == byte('.')
+	return !isRelative(path) && path[0] == byte('.')
+}
+
+func isRelative(path string) bool {
+	return len(path) > 1 && (path[:2] == "./" || path[:2] == ".\\" || path[:2] == "..")
 }


### PR DESCRIPTION
With this PR, todocheck can now work on windows. However, there is still a problem with the colors used to output error messages - they don't work on windows in their current form.

In a follow-up PR, I will fix the windows colors.

Related to #35 