### PR TITLE
fix bug with not being able to run todocheck from repo's root folder

### DIFF
--- a/traverser/lines/lines.go
+++ b/traverser/lines/lines.go
@@ -104,9 +104,9 @@ func isSupported(supportedExtensions []string, file string) bool {
 }
 
 func isHidden(path string) bool {
-	return !isRelative(path) && path[0] == byte('.')
+	return len(path) > 1 && !isRelative(path) && path[0] == byte('.')
 }
 
 func isRelative(path string) bool {
-	return len(path) > 1 && (path[:2] == "./" || path[:2] == ".\\" || path[:2] == "..")
+	return path[:2] == "./" || path[:2] == ".\\" || path[:2] == ".."
 }


### PR DESCRIPTION
There was a bug introduced to master in 15280a9a0377662c5423268797da1d22cc19872a.

When `todocheck` is run from the repository root without the `--basepath` argument, the current folder was `.` and it was considered an ignored file.

The problem was that the `len(path) > 1` check was extracted into the `isRelative` function & the check for `isHidden` didn't immediately stop when the length of the path was a single symbol.

This bug wasn't included in any release yet, so there is no need to make a new patch for it.