### PR TITLE
implement support for windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/fatih/color"
 	"github.com/preslavmihaylov/todocheck/authmanager"
 	"github.com/preslavmihaylov/todocheck/authmanager/authmiddleware"
 	todocheckerrors "github.com/preslavmihaylov/todocheck/checker/errors"
@@ -70,7 +71,7 @@ func printTodoErrs(errs []*todocheckerrors.TODO, format string) error {
 
 	if format == "standard" {
 		for _, err := range errs {
-			fmt.Fprintln(os.Stderr, err.Error())
+			fmt.Fprintln(color.Error, err.Error())
 		}
 	} else if format == "json" {
 		out := fmt.Sprintf("[%s", must(errs[0].ToJSON()))


### PR DESCRIPTION
Partial support for windows was added in #34 

The problem there was that the colors didn't appear on windows & instead some strange voodoo symbols showed up.

The problem was that we had to use the "colorful" stdout instead of the default `os.Stdout`, provided by `color.Output`.

It will use the standard `Stdout` for mac & linux, which support colors out of the box & the windows-specific one if the platform is windows.

closes #35 