### PR TITLE
Fix issue tracker auto detector's regex

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ var validIssueTrackers = []IssueTracker{
 
 var (
 	windowsAbsolutePathPattern = regexp.MustCompile("^[A-Z]{1}:")
-	gitRemoteOriginPattern     = regexp.MustCompile(`url\s=\s\w+(://|@)(?P<origin>(?P<host>.+?)(:|/).+)(\.git)?`)
+	gitRemoteOriginPattern     = regexp.MustCompile(`(?Um)url\s=\s\w+(://|@)(?P<origin>(?P<host>.+)?(:|/).+)(\.git)?$`)
 )
 
 // Local todocheck configuration struct definition


### PR DESCRIPTION
The new regex now detects `origin` and `host` better and totally ignores the existence of the `.git` part.

Fixes: #59 