### PR TITLE
Fix links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,14 +17,14 @@ submit a pull request. Please, try to follow these guidelines when you do so.
 ## Pull requests
 
 * Fork the project.
-* Write [good commit messages][https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html].
+* Write [good commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 * Use the [standard Go coding conventions and idioms](https://golang.org/doc/effective_go.html)
 * If your change has a corresponding open GitHub issue, add the following in the description `closes #issue-number`.
 * If the feature you are developing has external user impact (i.e. not a refactoring or internal improvement), then make sure to add appropriate tests for it.
   * The project has a set of integration tests, which run the actual program binary & test the output. Refer to `testing/todocheck_test.go` for examples.
   * If needed, extend the `testing/scenariobuilder` to incorporate your testing needs
 * Make sure the test suite is passing locally. It will otherwise fail on CI nevertheless.
-* Open a [pull request][https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests] that relates to *only* one subject with a clear title
+* Open a [pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) that relates to *only* one subject with a clear title
   and description in grammatically correct, complete sentences.
 
 ## Local Development


### PR DESCRIPTION
I was looking through the repo and found some funky links in the contributing guide. Here's the quick fix to get those looking right!