### PR TITLE
extract the config.Validate function into a separate package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -110,46 +109,6 @@ func autoDetect(basepath string) (*Local, error) {
 		IssueTracker: issueTracker,
 		Origin:       origin,
 	}, nil
-}
-
-// Validate validates the values of given configuration
-func (l *Local) Validate() []error {
-	var errors []error
-
-	if err := l.validateIssueTracker(); err != nil {
-		errors = append(errors, err)
-	}
-
-	if err := l.validateAuthOfflineURL(); err != nil {
-		errors = append(errors, err)
-	}
-
-	if l.IssueTracker != "" {
-		pattern, ok := originPatterns[l.IssueTracker]
-		if !ok || !pattern.MatchString(l.Origin) {
-			errors = append(errors, fmt.Errorf("%s is not a valid origin for issue tracker %s", l.Origin, l.IssueTracker))
-		}
-	}
-
-	return errors
-}
-
-func (l *Local) validateIssueTracker() error {
-	for _, issueTracker := range validIssueTrackers {
-		if l.IssueTracker == issueTracker {
-			return nil
-		}
-	}
-	return fmt.Errorf("invalid issue tracker: %q is not supported. the valid issue trackers are: %v",
-		l.IssueTracker, validIssueTrackers)
-}
-
-func (l *Local) validateAuthOfflineURL() error {
-	if _, err := url.ParseRequestURI(l.Auth.OfflineURL); l.Auth.Type == AuthTypeOffline && err != nil {
-		return fmt.Errorf("invalid offline URL: %q", l.Auth.OfflineURL)
-	}
-
-	return nil
 }
 
 func exists(filepath string) bool {

--- a/config/config.go
+++ b/config/config.go
@@ -14,39 +14,10 @@ import (
 // DefaultLocal contains the default filepath to the local todocheck config for the current repository
 const DefaultLocal = ".todocheck.yaml"
 
-// IssueTracker enum
-type IssueTracker string
-
-// Issue tracker types
-const (
-	IssueTrackerInvalid IssueTracker = ""
-	IssueTrackerJira                 = "JIRA"
-	IssueTrackerGithub               = "GITHUB"
-	IssueTrackerGitlab               = "GITLAB"
-	IssueTrackerPivotal              = "PIVOTAL_TRACKER"
-	IssueTrackerRedmine              = "REDMINE"
-)
-
-var validIssueTrackers = []IssueTracker{
-	IssueTrackerJira,
-	IssueTrackerGithub,
-	IssueTrackerGitlab,
-	IssueTrackerPivotal,
-	IssueTrackerRedmine,
-}
-
 var (
 	windowsAbsolutePathPattern = regexp.MustCompile("^[A-Z]{1}:")
 	gitRemoteOriginPattern     = regexp.MustCompile(`(?Um)url\s=\s\w+(://|@)(?P<origin>(?P<host>.+)?(:|/).+)(\.git)?$`)
 )
-
-var originPatterns = map[IssueTracker]*regexp.Regexp{
-	IssueTrackerJira:    regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9]+)+(:[0-9]+)?$`),
-	IssueTrackerGithub:  regexp.MustCompile(`^(https?://)?(www\.)?github\.com/[\w-]+/[\w-]+`),
-	IssueTrackerGitlab:  regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9]+)+(:[0-9]+)?/[\w-]+/[\w-]+$`),
-	IssueTrackerPivotal: regexp.MustCompile(`^(https?://)?(www\.)?pivotaltracker\.com/n/projects/[0-9]+`),
-	IssueTrackerRedmine: regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9]+)+(:[0-9]+)?$`),
-}
 
 // Local todocheck configuration struct definition
 type Local struct {

--- a/config/issuetracker.go
+++ b/config/issuetracker.go
@@ -1,0 +1,53 @@
+package config
+
+import "regexp"
+
+// IssueTracker enum
+type IssueTracker string
+
+// Issue tracker types
+const (
+	IssueTrackerInvalid IssueTracker = ""
+	IssueTrackerJira                 = "JIRA"
+	IssueTrackerGithub               = "GITHUB"
+	IssueTrackerGitlab               = "GITLAB"
+	IssueTrackerPivotal              = "PIVOTAL_TRACKER"
+	IssueTrackerRedmine              = "REDMINE"
+)
+
+var validIssueTrackers = []IssueTracker{
+	IssueTrackerJira,
+	IssueTrackerGithub,
+	IssueTrackerGitlab,
+	IssueTrackerPivotal,
+	IssueTrackerRedmine,
+}
+
+var originPatterns = map[IssueTracker]*regexp.Regexp{
+	IssueTrackerJira:    regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9]+)+(:[0-9]+)?$`),
+	IssueTrackerGithub:  regexp.MustCompile(`^(https?://)?(www\.)?github\.com/[\w-]+/[\w-]+`),
+	IssueTrackerGitlab:  regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9]+)+(:[0-9]+)?/[\w-]+/[\w-]+$`),
+	IssueTrackerPivotal: regexp.MustCompile(`^(https?://)?(www\.)?pivotaltracker\.com/n/projects/[0-9]+`),
+	IssueTrackerRedmine: regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9]+)+(:[0-9]+)?$`),
+}
+
+// IsValid checks if the given issue tracker is among the valid enum values
+func (it IssueTracker) IsValid() bool {
+	for _, other := range validIssueTrackers {
+		if it == other {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsValidOrigin checks if the given origin is among the valid patterns for the given issue tracker
+func (it IssueTracker) IsValidOrigin(origin string) bool {
+	pattern, ok := originPatterns[it]
+	if !ok || !pattern.MatchString(origin) {
+		return false
+	}
+
+	return true
+}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/preslavmihaylov/todocheck/fetcher"
 	"github.com/preslavmihaylov/todocheck/issuetracker"
 	"github.com/preslavmihaylov/todocheck/traverser/todoerrs"
+	"github.com/preslavmihaylov/todocheck/validation"
 )
 
 // set dynamically on build time. See Makefile for more info
@@ -41,7 +42,7 @@ func main() {
 		log.Fatalf("couldn't open configuration file: %s\n", err)
 	}
 
-	if errors := localCfg.Validate(); len(errors) > 0 {
+	if errors := validation.Validate(localCfg); len(errors) > 0 {
 		for _, err := range errors {
 			log.Println(err)
 		}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Validate validates the values of given configuration
-func Validate(cfg config.Local) []error {
+func Validate(cfg *config.Local) []error {
 	var errors []error
 
 	if err := validateIssueTracker(cfg); err != nil {
@@ -26,7 +26,7 @@ func Validate(cfg config.Local) []error {
 	return errors
 }
 
-func validateIssueTracker(cfg config.Local) error {
+func validateIssueTracker(cfg *config.Local) error {
 	if !cfg.IssueTracker.IsValid() {
 		return fmt.Errorf("invalid issue tracker: %q is not supported", cfg.IssueTracker)
 	}
@@ -34,7 +34,7 @@ func validateIssueTracker(cfg config.Local) error {
 	return nil
 }
 
-func validateAuthOfflineURL(cfg config.Local) error {
+func validateAuthOfflineURL(cfg *config.Local) error {
 	if _, err := url.ParseRequestURI(cfg.Auth.OfflineURL); cfg.Auth.Type == config.AuthTypeOffline && err != nil {
 		return fmt.Errorf("invalid offline URL: %q", cfg.Auth.OfflineURL)
 	}
@@ -42,7 +42,7 @@ func validateAuthOfflineURL(cfg config.Local) error {
 	return nil
 }
 
-func validateIssueTrackerOrigin(cfg config.Local) error {
+func validateIssueTrackerOrigin(cfg *config.Local) error {
 	if cfg.IssueTracker != "" && !cfg.IssueTracker.IsValidOrigin(cfg.Origin) {
 		return fmt.Errorf("%s is not a valid origin for issue tracker %s", cfg.Origin, cfg.IssueTracker)
 	}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -1,0 +1,51 @@
+package validation
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/preslavmihaylov/todocheck/config"
+)
+
+// Validate validates the values of given configuration
+func Validate(cfg config.Local) []error {
+	var errors []error
+
+	if err := validateIssueTracker(cfg); err != nil {
+		errors = append(errors, err)
+	}
+
+	if err := validateAuthOfflineURL(cfg); err != nil {
+		errors = append(errors, err)
+	}
+
+	if err := validateIssueTrackerOrigin(cfg); err != nil {
+		errors = append(errors, err)
+	}
+
+	return errors
+}
+
+func validateIssueTracker(cfg config.Local) error {
+	if !cfg.IssueTracker.IsValid() {
+		return fmt.Errorf("invalid issue tracker: %q is not supported", cfg.IssueTracker)
+	}
+
+	return nil
+}
+
+func validateAuthOfflineURL(cfg config.Local) error {
+	if _, err := url.ParseRequestURI(cfg.Auth.OfflineURL); cfg.Auth.Type == config.AuthTypeOffline && err != nil {
+		return fmt.Errorf("invalid offline URL: %q", cfg.Auth.OfflineURL)
+	}
+
+	return nil
+}
+
+func validateIssueTrackerOrigin(cfg config.Local) error {
+	if cfg.IssueTracker != "" && !cfg.IssueTracker.IsValidOrigin(cfg.Origin) {
+		return fmt.Errorf("%s is not a valid origin for issue tracker %s", cfg.Origin, cfg.IssueTracker)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This refactor would allow future changes to the `Validate` function to include dependencies on `issuetracker` and others which is not currently possible as that would lead to cyclic dependencies.