### PR TITLE
unblock issues caused by bad validation

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,17 +42,17 @@ func main() {
 		log.Fatalf("couldn't open configuration file: %s\n", err)
 	}
 
+	err = authmanager.AcquireToken(localCfg)
+	if err != nil {
+		log.Fatalf("couldn't acquire token from config: %s\n", err)
+	}
+
 	if errors := validation.Validate(localCfg); len(errors) > 0 {
 		for _, err := range errors {
 			log.Println(err)
 		}
 
 		os.Exit(1)
-	}
-
-	err = authmanager.AcquireToken(localCfg)
-	if err != nil {
-		log.Fatalf("couldn't acquire token from config: %s\n", err)
 	}
 
 	baseURL, err := issuetracker.BaseURLFor(localCfg.IssueTracker, localCfg.Origin)

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -27,10 +27,6 @@ func Validate(cfg *config.Local) []error {
 		errs = append(errs, err)
 	}
 
-	// if err := validateIssueTrackerExists(cfg); err != nil {
-	// 	errs = append(errs, err)
-	// }
-
 	if err := validateAuthType(cfg); err != nil {
 		errs = append(errs, err)
 	}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -27,9 +27,9 @@ func Validate(cfg *config.Local) []error {
 		errs = append(errs, err)
 	}
 
-	if err := validateIssueTrackerExists(cfg); err != nil {
-		errs = append(errs, err)
-	}
+	// if err := validateIssueTrackerExists(cfg); err != nil {
+	// 	errs = append(errs, err)
+	// }
 
 	if err := validateAuthType(cfg); err != nil {
 		errs = append(errs, err)


### PR DESCRIPTION
Part 1 for #78 

 * Acquire the auth token before the validation begins to avoid displaying the github warning every time
 * Remove the issue tracker exists validation as it always fails for private github repositories

The fix I've made here addresses the issue with the warning always present and partially, the one with always failing validation for private github repositories.

What's left is to also include the authentication middleware in calls to `fetcher.IsHealthy`

I will do that after finishing the refactorings started in #81.
For the time being, I've removed that validation to unblock master from not working with private github repositories.