### PR TITLE
re-fixes issue #71 broken by PR #85

### DIFF
--- a/authmanager/authmanager.go
+++ b/authmanager/authmanager.go
@@ -37,7 +37,7 @@ func AcquireToken(cfg *config.Local) error {
 	case config.AuthTypeOffline:
 		return acquireOfflineToken(cfg.Auth)
 	default:
-		panic("this shouldn't have happened, don't know what to do here")
+		panic("It's on us! Don't know how to handle this authentication token type. Please file an issue here - https://github.com/preslavmihaylov/todocheck/issues/new")
 	}
 }
 

--- a/authmanager/authmanager.go
+++ b/authmanager/authmanager.go
@@ -24,6 +24,11 @@ const (
 
 // AcquireToken stores the issue tracker's auth token based on the auth type specified
 func AcquireToken(cfg *config.Local) error {
+
+	if !cfg.Auth.Type.IsValid() {
+		return fmt.Errorf("invalid auth type: %q. valid auth types are: %q", cfg.Auth.Type, config.ValidAuthTypes)
+	}
+
 	switch cfg.Auth.Type {
 	case config.AuthTypeNone:
 		return nil
@@ -32,7 +37,7 @@ func AcquireToken(cfg *config.Local) error {
 	case config.AuthTypeOffline:
 		return acquireOfflineToken(cfg.Auth)
 	default:
-		panic("unknown auth token type")
+		panic("this shouldn't have happened, don't know what to do here")
 	}
 }
 

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -27,10 +27,6 @@ func Validate(cfg *config.Local) []error {
 		errs = append(errs, err)
 	}
 
-	if err := validateAuthType(cfg); err != nil {
-		errs = append(errs, err)
-	}
-
 	if cfg.Auth.Token == "" && cfg.IssueTracker == config.IssueTrackerGithub {
 		fmt.Fprintln(color.Output, color.YellowString(
 			"WARNING: Github has API rate limits for all requests which do not contain a token.\n"+
@@ -77,15 +73,6 @@ func validateIssueTrackerExists(cfg *config.Local) error {
 
 	if !fetcher.IsHealthy(cfg.IssueTracker, url) {
 		return fmt.Errorf("repository %s not found. Is the repository private? More info: https://github.com/preslavmihaylov/todocheck#github", url)
-	}
-
-	return nil
-}
-
-func validateAuthType(cfg *config.Local) error {
-
-	if !cfg.Auth.Type.IsValid() {
-		return fmt.Errorf("invalid auth type: %q. valid auth types are: %q", cfg.Auth.Type, config.ValidAuthTypes)
 	}
 
 	return nil


### PR DESCRIPTION
Application panicked if an incorrect auth type was in `.todocheck.yaml`. 
It was fixed but then PR #85 made the change to acquire the auth token before the validation begins to avoid displaying the github warning every time. This way an incorrect auth type was no longer validated. 
The fix was to put the auth type validation in the acquire token function.