### PR TITLE
make CI tests runnable on forks

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     branches:
       - master
 


### PR DESCRIPTION
related to #99 

Currently, the tests which are meant to be run on CI only always fail when executed on forks (e.g. pull requests from non-maintainers). The reason is that the secrets needed to execute those tests are not available in the forked branches.

With this `pull_request_target` option, according to [the docs](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/), the workflows of such PRs will be run from the context of the target repo, meaning that the secrets should be available to workflows from fork PRs and the running workflows will not be modifiable from such people, which would risk exposing the secrets.