### PR TITLE
checkout correct code when running CI steps

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -13,12 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Build binary
         run: make build
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Run tests
         env:
           TODOCHECK_ENV: "ci"


### PR DESCRIPTION
After merging #102, the PRs from forks can correctly use github secrets & run the CI tests.

However, the workflows use not only the secrets & workflows from the target repo, but also the code.
Meaning that the worklows are not running against the forked repo, but against the target repo, making the workflows meaningless.

This change will, hopefully, make the CI tests runnable on forks but also execute workflows against the forked code.