### PR TITLE
improve secret tokens security in CI

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - improve-workflow-security
   pull_request_target:
     branches:
       - master

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - improve-workflow-security
   pull_request_target:
     branches:
       - master
@@ -25,6 +26,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
       - name: Run tests
         env:
           TODOCHECK_ENV: "ci"


### PR DESCRIPTION
The new option for `actions/checkout` will make it so workflows don't persist the secrets in the local git config, which enables one to read them from there.