### PR TITLE
add ci tests for gitlab integration

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -3,6 +3,8 @@ name: master
 on:
   push:
   pull_request_target:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -3,8 +3,6 @@ name: master
 on:
   push:
   pull_request_target:
-    branches:
-      - master
 
 jobs:
   build:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -30,4 +30,5 @@ jobs:
         env:
           TODOCHECK_ENV: "ci"
           TESTS_GITHUB_APITOKEN: ${{ secrets.TESTS_GITHUB_APITOKEN }}
+          TESTS_GITLAB_APITOKEN: ${{ secrets.TESTS_GITLAB_APITOKEN }}
         run: make test

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -2,8 +2,6 @@ name: master
 
 on:
   push:
-    branches:
-      - master
   pull_request_target:
     branches:
       - master

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	go build -ldflags "-X main.version=$(version)"
 
 test: build
-	go test -v -count=1 ./testing
+	go test -count=1 ./testing
 
 release:
 	@echo "Generating binaries for version $(version)..."

--- a/testing/integrations_test.go
+++ b/testing/integrations_test.go
@@ -27,11 +27,31 @@ func TestPrivateGithubIntegration(t *testing.T) {
 	}
 }
 
+func TestPublicGitlabIntegration(t *testing.T) {
+	err := baseGitlabScenario().
+		OnlyRunOnCI().
+		WithConfig("./test_configs/integrations/gitlab_public.yaml").
+		Run()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+}
+
+func TestPrivateGitlabIntegration(t *testing.T) {
+	err := baseGitlabScenario().
+		OnlyRunOnCI().
+		WithConfig("./test_configs/integrations/gitlab_private.yaml").
+		Run()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+}
+
 func baseGithubScenario() *scenariobuilder.TodocheckScenario {
 	return scenariobuilder.NewScenario().
 		WithBinary("../todocheck").
 		WithBasepath("./scenarios/integrations/github").
-		WithAuthTokenFromEnv("TESTS_GITHUB_APITOKEN").
+		WithAuthTokenFromEnv("TESTS_GITLAB_APITOKEN").
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeIssueClosed).
@@ -52,4 +72,8 @@ func baseGithubScenario() *scenariobuilder.TodocheckScenario {
 				WithType(errors.TODOErrTypeNonExistentIssue).
 				WithLocation("scenarios/integrations/github/main.go", 9).
 				ExpectLine("// TODO #3: A non-existent issue"))
+}
+
+func baseGitlabScenario() *scenariobuilder.TodocheckScenario {
+	return baseGithubScenario()
 }

--- a/testing/integrations_test.go
+++ b/testing/integrations_test.go
@@ -10,6 +10,7 @@ import (
 func TestPublicGithubIntegration(t *testing.T) {
 	err := baseGithubScenario().
 		OnlyRunOnCI().
+		WithAuthTokenFromEnv("TESTS_GITHUB_APITOKEN").
 		WithConfig("./test_configs/integrations/github_public.yaml").
 		Run()
 	if err != nil {
@@ -20,6 +21,7 @@ func TestPublicGithubIntegration(t *testing.T) {
 func TestPrivateGithubIntegration(t *testing.T) {
 	err := baseGithubScenario().
 		OnlyRunOnCI().
+		WithAuthTokenFromEnv("TESTS_GITHUB_APITOKEN").
 		WithConfig("./test_configs/integrations/github_private.yaml").
 		Run()
 	if err != nil {
@@ -30,6 +32,7 @@ func TestPrivateGithubIntegration(t *testing.T) {
 func TestPublicGitlabIntegration(t *testing.T) {
 	err := baseGitlabScenario().
 		OnlyRunOnCI().
+		WithAuthTokenFromEnv("TESTS_GITLAB_APITOKEN").
 		WithConfig("./test_configs/integrations/gitlab_public.yaml").
 		Run()
 	if err != nil {
@@ -40,6 +43,7 @@ func TestPublicGitlabIntegration(t *testing.T) {
 func TestPrivateGitlabIntegration(t *testing.T) {
 	err := baseGitlabScenario().
 		OnlyRunOnCI().
+		WithAuthTokenFromEnv("TESTS_GITLAB_APITOKEN").
 		WithConfig("./test_configs/integrations/gitlab_private.yaml").
 		Run()
 	if err != nil {
@@ -51,7 +55,6 @@ func baseGithubScenario() *scenariobuilder.TodocheckScenario {
 	return scenariobuilder.NewScenario().
 		WithBinary("../todocheck").
 		WithBasepath("./scenarios/integrations/github").
-		WithAuthTokenFromEnv("TESTS_GITLAB_APITOKEN").
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeIssueClosed).

--- a/testing/test_configs/integrations/gitlab_private.yaml
+++ b/testing/test_configs/integrations/gitlab_private.yaml
@@ -1,0 +1,4 @@
+origin: https://gitlab.com/todocheck-tests/test-private
+issue_tracker: GITLAB
+auth:
+  type: apitoken

--- a/testing/test_configs/integrations/gitlab_public.yaml
+++ b/testing/test_configs/integrations/gitlab_public.yaml
@@ -1,0 +1,4 @@
+origin: https://gitlab.com/todocheck-tests/test-public
+issue_tracker: GITLAB
+auth:
+  type: apitoken


### PR DESCRIPTION
Related to #120 

One of the CI steps fail because the new secret is not available for pull_request_target runs. As observed, when the event is `push`, the step passes. After this is merged, the failing step will, hence, start passing.

In addition to this, I've decided to reduce the test verbosity to more easily identify which tests are failing.