### PR TITLE
add pivotaltracker CI tests

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -29,4 +29,5 @@ jobs:
           TODOCHECK_ENV: "ci"
           TESTS_GITHUB_APITOKEN: ${{ secrets.TESTS_GITHUB_APITOKEN }}
           TESTS_GITLAB_APITOKEN: ${{ secrets.TESTS_GITLAB_APITOKEN }}
+          TESTS_PIVOTALTRACKER_APITOKEN: ${{ secrets.TESTS_PIVOTALTRACKER_APITOKEN }}
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	go build -ldflags "-X main.version=$(version)"
 
 test: build
-	go test -count=1 ./testing
+	go test -v -count=1 ./testing
 
 release:
 	@echo "Generating binaries for version $(version)..."

--- a/testing/integrations_test.go
+++ b/testing/integrations_test.go
@@ -51,6 +51,44 @@ func TestPrivateGitlabIntegration(t *testing.T) {
 	}
 }
 
+func TestPivotalTrackerIntegration(t *testing.T) {
+	err := scenariobuilder.NewScenario().
+		OnlyRunOnCI().
+		WithBinary("../todocheck").
+		WithBasepath("./scenarios/integrations/pivotaltracker").
+		WithAuthTokenFromEnv("TESTS_PIVOTALTRACKER_APITOKEN").
+		WithConfig("./test_configs/integrations/pivotaltracker.yaml").
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeIssueClosed).
+				WithLocation("scenarios/integrations/pivotaltracker/main.go", 5).
+				ExpectLine("// TODO #175938853: A finished todo (closed)")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeIssueClosed).
+				WithLocation("scenarios/integrations/pivotaltracker/main.go", 7).
+				ExpectLine("// TODO #175938860: A delivered todo (closed)")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeIssueClosed).
+				WithLocation("scenarios/integrations/pivotaltracker/main.go", 11).
+				ExpectLine("// TODO #175938899: A rejected todo (closed)")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeIssueClosed).
+				WithLocation("scenarios/integrations/pivotaltracker/main.go", 13).
+				ExpectLine("// TODO #175938883: An accepted todo (closed)")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeNonExistentIssue).
+				WithLocation("scenarios/integrations/pivotaltracker/main.go", 15).
+				ExpectLine("// TODO #199938883: A non-existent issue")).
+		Run()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+}
+
 func baseGithubScenario() *scenariobuilder.TodocheckScenario {
 	return scenariobuilder.NewScenario().
 		WithBinary("../todocheck").

--- a/testing/scenarios/integrations/pivotaltracker/main.go
+++ b/testing/scenarios/integrations/pivotaltracker/main.go
@@ -1,0 +1,15 @@
+package main
+
+// TODO #175938845: A started todo (open)
+
+// TODO #175938853: A finished todo (closed)
+
+// TODO #175938860: A delivered todo (closed)
+
+// TODO #175938836: An unstarted todo (open)
+
+// TODO #175938899: A rejected todo (closed)
+
+// TODO #175938883: An accepted todo (closed)
+
+// TODO #199938883: A non-existent issue

--- a/testing/test_configs/integrations/pivotaltracker.yaml
+++ b/testing/test_configs/integrations/pivotaltracker.yaml
@@ -1,0 +1,4 @@
+origin: https://www.pivotaltracker.com/n/projects/2459511
+issue_tracker: PIVOTAL_TRACKER
+auth:
+  type: apitoken


### PR DESCRIPTION
Similarly to #119 and #99 I'm creating CI tests for pivotaltracker.

For this purpose, I've created an account on their site with read-only access to a pivotaltracker project with a set of hardcoded issues with all various statuses.

For each of them, I've created a separate todo line in the tests in this PR to verify we can correctly unmarshal the response received from their API.

I also changed my mind about removing the verbosity of tests as making them non-verbose turned out to make it quite hard to see where the issue is due to mised standard output from tests and the testing output

The `pull_request_target` tests are failing as they are using the workflow from the master branch, which doesn't include the new secret. This is expected.