### PR TITLE
add funding option for repo

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: preslavmihaylov


### PR DESCRIPTION
This will enable the `Sponsor` button and allow supporters to fund the project via Github Sponsors