### PR TITLE
extract the token acquisition message routine into the issuetracker components

### DIFF
--- a/issuetracker/factory/factory.go
+++ b/issuetracker/factory/factory.go
@@ -17,15 +17,15 @@ import (
 func NewIssueTrackerFrom(issueTrackerType config.IssueTracker, authCfg *config.Auth, origin string) (issuetracker.IssueTracker, error) {
 	switch issueTrackerType {
 	case config.IssueTrackerGithub:
-		return &github.IssueTracker{Origin: origin, AuthCfg: authCfg}, nil
+		return github.New(origin, authCfg)
 	case config.IssueTrackerJira:
-		return &jira.IssueTracker{Origin: origin, AuthCfg: authCfg}, nil
+		return jira.New(origin, authCfg)
 	case config.IssueTrackerGitlab:
-		return &gitlab.IssueTracker{Origin: origin, AuthCfg: authCfg}, nil
+		return gitlab.New(origin, authCfg)
 	case config.IssueTrackerRedmine:
-		return &redmine.IssueTracker{Origin: origin, AuthCfg: authCfg}, nil
+		return redmine.New(origin, authCfg)
 	case config.IssueTrackerPivotal:
-		return &pivotaltracker.IssueTracker{Origin: origin, AuthCfg: authCfg}, nil
+		return pivotaltracker.New(origin, authCfg)
 	}
 
 	return nil, errors.New("unknown issue tracker " + string(issueTrackerType))

--- a/issuetracker/internal/github/github.go
+++ b/issuetracker/internal/github/github.go
@@ -10,6 +10,11 @@ import (
 	"github.com/preslavmihaylov/todocheck/issuetracker"
 )
 
+// New creates a new github issuetracker instance
+func New(origin string, authCfg *config.Auth) (*IssueTracker, error) {
+	return &IssueTracker{origin, authCfg}, nil
+}
+
 // IssueTracker implementation for integrating with public & private github issue trackers
 type IssueTracker struct {
 	Origin  string
@@ -44,6 +49,16 @@ func (it *IssueTracker) InstrumentMiddleware(r *http.Request) error {
 	common.Assert(it.AuthCfg.Token != "", "authentication token is empty")
 	r.Header.Add("Authorization", "Bearer "+it.AuthCfg.Token)
 	return nil
+}
+
+// TokenAcquisitionInstructions returns instructions for manually acquiring the authentication token
+// for github and the given authentication type
+func (it *IssueTracker) TokenAcquisitionInstructions() string {
+	if it.AuthCfg.Type == config.AuthTypeNone {
+		return ""
+	}
+
+	return "Please go to https://github.com/settings/tokens, create a read-only access token & paste it here."
 }
 
 // taskURLFrom taskID returns the url for the target github task ID to fetch

--- a/issuetracker/internal/jira/jira.go
+++ b/issuetracker/internal/jira/jira.go
@@ -9,6 +9,11 @@ import (
 	"github.com/preslavmihaylov/todocheck/issuetracker"
 )
 
+// New creates a new jira issuetracker instance
+func New(origin string, authCfg *config.Auth) (*IssueTracker, error) {
+	return &IssueTracker{origin, authCfg}, nil
+}
+
 // IssueTracker is an issue tracker implementation for integrating with private Jira servers
 type IssueTracker struct {
 	Origin  string
@@ -42,6 +47,12 @@ func (it *IssueTracker) InstrumentMiddleware(r *http.Request) error {
 	common.Assert(it.AuthCfg.Token != "", "authentication token is empty")
 	r.Header.Add("Authorization", "Bearer "+it.AuthCfg.Token)
 	return nil
+}
+
+// TokenAcquisitionInstructions returns instructions for manually acquiring the authentication token
+// for jira and the given authentication type
+func (it *IssueTracker) TokenAcquisitionInstructions() string {
+	return fmt.Sprintf("Please go to %s and paste the offline token below.", it.AuthCfg.OfflineURL)
 }
 
 // TaskURLFrom taskID returns the url for the target Jira task ID to fetch

--- a/issuetracker/internal/pivotaltracker/pivotaltracker.go
+++ b/issuetracker/internal/pivotaltracker/pivotaltracker.go
@@ -10,6 +10,11 @@ import (
 	"github.com/preslavmihaylov/todocheck/issuetracker"
 )
 
+// New creates a new pivotaltracker issuetracker instance
+func New(origin string, authCfg *config.Auth) (*IssueTracker, error) {
+	return &IssueTracker{origin, authCfg}, nil
+}
+
 // IssueTracker implementation for integrating with public pivotaltracker issue trackers
 type IssueTracker struct {
 	Origin  string
@@ -43,6 +48,12 @@ func (it *IssueTracker) InstrumentMiddleware(r *http.Request) error {
 	common.Assert(it.AuthCfg.Token != "", "authentication token is empty")
 	r.Header.Add("X-TrackerToken", it.AuthCfg.Token)
 	return nil
+}
+
+// TokenAcquisitionInstructions returns instructions for manually acquiring the authentication token
+// for pivotaltracker and the given authentication type
+func (it *IssueTracker) TokenAcquisitionInstructions() string {
+	return "Please go to https://www.pivotaltracker.com/profile, create a new API token & paste it here."
 }
 
 // TaskURLFrom taskID returns the url for the target pivotaltracker task ID to fetch

--- a/issuetracker/internal/redmine/redmine.go
+++ b/issuetracker/internal/redmine/redmine.go
@@ -10,6 +10,11 @@ import (
 	"github.com/preslavmihaylov/todocheck/issuetracker"
 )
 
+// New creates a new redmine issuetracker instance
+func New(origin string, authCfg *config.Auth) (*IssueTracker, error) {
+	return &IssueTracker{origin, authCfg}, nil
+}
+
 // IssueTracker implementation for integrating with public & private redmine issue trackers
 type IssueTracker struct {
 	Origin  string
@@ -43,6 +48,16 @@ func (it *IssueTracker) InstrumentMiddleware(r *http.Request) error {
 	common.Assert(it.AuthCfg.Token != "", "authentication token is empty")
 	r.Header.Add("X-Redmine-API-Key", it.AuthCfg.Token)
 	return nil
+}
+
+// TokenAcquisitionInstructions returns instructions for manually acquiring the authentication token
+// for pivotaltracker and the given authentication type
+func (it *IssueTracker) TokenAcquisitionInstructions() string {
+	if it.AuthCfg.Type == config.AuthTypeNone {
+		return ""
+	}
+
+	return fmt.Sprintf("Please go to %s/my/account, create a new API token & paste it here.", it.Origin)
 }
 
 // TaskURLFrom taskID returns the url for the target redmine task ID to fetch

--- a/issuetracker/issuetracker.go
+++ b/issuetracker/issuetracker.go
@@ -29,4 +29,7 @@ type IssueTracker interface {
 
 	// InstrumentMiddleware is a hook to instrument any necessary middleware for connecting with the issue tracker
 	InstrumentMiddleware(r *http.Request) error
+
+	// TokenAcquisitionInstructions returns instructions for manually acquiring the authentication token
+	TokenAcquisitionInstructions() string
 }

--- a/main.go
+++ b/main.go
@@ -45,14 +45,14 @@ func main() {
 		log.Fatalf("couldn't open configuration file: %s\n", err)
 	}
 
-	err = authmanager.AcquireToken(localCfg)
-	if err != nil {
-		log.Fatalf("couldn't acquire token from config: %s\n", err)
-	}
-
 	tracker, err := factory.NewIssueTrackerFrom(localCfg.IssueTracker, localCfg.Auth, localCfg.Origin)
 	if err != nil {
 		log.Fatalf("couldn't create new issue tracker: %s\n", err)
+	}
+
+	err = authmanager.AcquireToken(localCfg, tracker)
+	if err != nil {
+		log.Fatalf("couldn't acquire token from config: %s\n", err)
 	}
 
 	if errors := validation.Validate(localCfg, tracker); len(errors) > 0 {

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -30,6 +30,11 @@ func (m *mockIssueTracker) InstrumentMiddleware(r *http.Request) error {
 	panic("not implemented") // TODO: Implement
 }
 
+// TokenAcquisitionInstructions returns instructions for manually acquiring the authentication token
+func (m *mockIssueTracker) TokenAcquisitionInstructions() string {
+	panic("not implemented") // TODO: Implement
+}
+
 func TestInvalidOrigins(t *testing.T) {
 	invalidConfigPaths := []string{
 		"./fixtures/invalid/invalid_github_https.yaml",


### PR DESCRIPTION
This PR extracts the final piece of specific issue tracker mechanisms to the `issuetracker.IssueTracker` interface.

This is the custom token acquisition message one receives when running `todocheck` initially on their project.

The texts themselves aren't changed. I've verified the refactoring by testing the changes to the message opening. I've also opened a new issue - #130, to verify this functionality in the tests as well.