### PR TITLE
fixes #121 token passed via env variable is no longer cached

### DIFF
--- a/authmanager/authmanager.go
+++ b/authmanager/authmanager.go
@@ -54,7 +54,9 @@ func acquireToken(authCfg *config.Auth, tokenKey string, instructions string) er
 		authCfg.Token = store.Tokens[tokenKey]
 		return nil
 	} else if envToken := os.Getenv(authTokenEnvVariable); envToken != "" {
-		return setAndPersistToken(authCfg, store, tokenKey, envToken)
+		authCfg.Token = envToken
+		store.Tokens[tokenKey] = authCfg.Token
+		return nil
 	}
 
 	fmt.Printf("%s\nToken: ", instructions)

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -16,9 +16,15 @@ func Validate(cfg *config.Local, tracker issuetracker.IssueTracker) []error {
 		errs = append(errs, err)
 	}
 
-	if err := validateAuthOfflineURL(cfg); err != nil {
-		errs = append(errs, err)
+	if cfg.Auth.Type == config.AuthTypeOffline{
+		if err := validateAuthOfflineURL(cfg); err != nil {
+			errs = append(errs, err)
+		}
+		if err := validateAuthOfflineUrlIsSet(cfg); err != nil {
+			errs = append(errs,err)
+		}
 	}
+
 
 	if err := validateIssueTrackerOrigin(cfg); err != nil {
 		errs = append(errs, err)
@@ -47,8 +53,16 @@ func validateIssueTracker(cfg *config.Local) error {
 }
 
 func validateAuthOfflineURL(cfg *config.Local) error {
-	if _, err := url.ParseRequestURI(cfg.Auth.OfflineURL); cfg.Auth.Type == config.AuthTypeOffline && err != nil {
+	if _, err := url.ParseRequestURI(cfg.Auth.OfflineURL); err != nil {
 		return fmt.Errorf("invalid offline URL: %q", cfg.Auth.OfflineURL)
+	}
+
+	return nil
+}
+
+func validateAuthOfflineUrlIsSet(cfg *config.Local) error {
+	if cfg.Auth.OfflineURL==""{
+		return fmt.Errorf("auth type chosen was %q but \"offline_url\" is not set", cfg.Auth.Type)
 	}
 
 	return nil


### PR DESCRIPTION
Removal of setAndPersistToken call and saving the token in memory.
The call mentioned above would always save the token which is not the required behavior.
The token will now be properly cached on ~/todocheck/authtokens.yaml only when it is set in the config file.