### PR TITLE
fixes#129 offline_url validation

### DIFF
--- a/validation/validation.go
+++ b/validation/validation.go
@@ -17,9 +17,9 @@ func Validate(cfg *config.Local, tracker issuetracker.IssueTracker) []error {
 	}
 
 	if cfg.Auth.Type == config.AuthTypeOffline {
-		if err := validateAuthOfflineURL(cfg); err != nil {
+		if err := validateAuthOfflineURLIsSet(cfg); err != nil {
 			errs = append(errs, err)
-		} else if err := validateAuthOfflineURLIsSet(cfg); err != nil {
+		} else if err := validateAuthOfflineURL(cfg); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -19,8 +19,7 @@ func Validate(cfg *config.Local, tracker issuetracker.IssueTracker) []error {
 	if cfg.Auth.Type == config.AuthTypeOffline{
 		if err := validateAuthOfflineURL(cfg); err != nil {
 			errs = append(errs, err)
-		}
-		if err := validateAuthOfflineUrlIsSet(cfg); err != nil {
+		}else if err := validateAuthOfflineURLIsSet(cfg); err != nil {
 			errs = append(errs,err)
 		}
 	}
@@ -60,7 +59,7 @@ func validateAuthOfflineURL(cfg *config.Local) error {
 	return nil
 }
 
-func validateAuthOfflineUrlIsSet(cfg *config.Local) error {
+func validateAuthOfflineURLIsSet(cfg *config.Local) error {
 	if cfg.Auth.OfflineURL==""{
 		return fmt.Errorf("auth type chosen was %q but \"offline_url\" is not set", cfg.Auth.Type)
 	}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -16,14 +16,13 @@ func Validate(cfg *config.Local, tracker issuetracker.IssueTracker) []error {
 		errs = append(errs, err)
 	}
 
-	if cfg.Auth.Type == config.AuthTypeOffline{
+	if cfg.Auth.Type == config.AuthTypeOffline {
 		if err := validateAuthOfflineURL(cfg); err != nil {
 			errs = append(errs, err)
-		}else if err := validateAuthOfflineURLIsSet(cfg); err != nil {
-			errs = append(errs,err)
+		} else if err := validateAuthOfflineURLIsSet(cfg); err != nil {
+			errs = append(errs, err)
 		}
 	}
-
 
 	if err := validateIssueTrackerOrigin(cfg); err != nil {
 		errs = append(errs, err)
@@ -60,7 +59,7 @@ func validateAuthOfflineURL(cfg *config.Local) error {
 }
 
 func validateAuthOfflineURLIsSet(cfg *config.Local) error {
-	if cfg.Auth.OfflineURL==""{
+	if cfg.Auth.OfflineURL == "" {
 		return fmt.Errorf("auth type chosen was %q but \"offline_url\" is not set", cfg.Auth.Type)
 	}
 

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -16,9 +16,15 @@ func Validate(cfg *config.Local, tracker issuetracker.IssueTracker) []error {
 		errs = append(errs, err)
 	}
 
-	if err := validateAuthOfflineURL(cfg); err != nil {
-		errs = append(errs, err)
+	if cfg.Auth.Type == config.AuthTypeOffline{
+		if err := validateAuthOfflineURL(cfg); err != nil {
+			errs = append(errs, err)
+		}
+		if err := validateAuthOfflineUrlIsSet(cfg); err != nil {
+			errs = append(errs,err)
+		}
 	}
+
 
 	if err := validateIssueTrackerOrigin(cfg); err != nil {
 		errs = append(errs, err)
@@ -47,8 +53,16 @@ func validateIssueTracker(cfg *config.Local) error {
 }
 
 func validateAuthOfflineURL(cfg *config.Local) error {
-	if _, err := url.ParseRequestURI(cfg.Auth.OfflineURL); cfg.Auth.Type == config.AuthTypeOffline && err != nil {
+	if _, err := url.ParseRequestURI(cfg.Auth.OfflineURL); err != nil {
 		return fmt.Errorf("invalid offline URL: %q", cfg.Auth.OfflineURL)
+	}
+
+	return nil
+}
+
+func validateAuthOfflineUrlIsSet(cfg *config.Local) error {
+	if cfg.Auth.OfflineURL==""{
+		return fmt.Errorf("auth type chosen was %q but \"offline_url\" is not set", cfg.Auth.Type)
 	}
 
 	return nil


### PR DESCRIPTION
Closes #129 

Validate now checks if offline_url is an empty when auth type offline is being used. returns an error is it's not set 