### PR TITLE
fixes #121 token passed via env variable is no longer cached

### DIFF
--- a/authmanager/authmanager.go
+++ b/authmanager/authmanager.go
@@ -54,7 +54,9 @@ func acquireToken(authCfg *config.Auth, tokenKey string, instructions string) er
 		authCfg.Token = store.Tokens[tokenKey]
 		return nil
 	} else if envToken := os.Getenv(authTokenEnvVariable); envToken != "" {
-		return setAndPersistToken(authCfg, store, tokenKey, envToken)
+		authCfg.Token = envToken
+		store.Tokens[tokenKey] = authCfg.Token
+		return nil
 	}
 
 	fmt.Printf("%s\nToken: ", instructions)

--- a/authmanager/authmanager.go
+++ b/authmanager/authmanager.go
@@ -55,7 +55,6 @@ func acquireToken(authCfg *config.Auth, tokenKey string, instructions string) er
 		return nil
 	} else if envToken := os.Getenv(authTokenEnvVariable); envToken != "" {
 		authCfg.Token = envToken
-		store.Tokens[tokenKey] = authCfg.Token
 		return nil
 	}
 

--- a/testing/scenariobuilder/builder.go
+++ b/testing/scenariobuilder/builder.go
@@ -273,7 +273,13 @@ func (s *TodocheckScenario) Run() error {
 
 	validateFuncs := []validateFunc{
 		validateTodoFunc,
-		validateAuthTokensCache(s.cfg.Auth.TokensCache, s.cfg.Auth.OfflineURL, s.expectedAuthToken),
+	}
+
+	// only run the TokenCache validation when the environment variable is not set
+	// this test will always fail since the cache is not generated when the
+	// token is set via an environment variable
+	if s.authTokenEnvVariable == "" {
+		validateFuncs = append(validateFuncs,validateAuthTokensCache(s.cfg.Auth.TokensCache, s.cfg.Auth.OfflineURL, s.expectedAuthToken))
 	}
 
 	if s.expectedExitCode == 1 {

--- a/testing/scenariobuilder/builder.go
+++ b/testing/scenariobuilder/builder.go
@@ -279,7 +279,7 @@ func (s *TodocheckScenario) Run() error {
 	// this test will always fail since the cache is not generated when the
 	// token is set via an environment variable
 	if s.authTokenEnvVariable == "" {
-		validateFuncs = append(validateFuncs,validateAuthTokensCache(s.cfg.Auth.TokensCache, s.cfg.Auth.OfflineURL, s.expectedAuthToken))
+		validateFuncs = append(validateFuncs, validateAuthTokensCache(s.cfg.Auth.TokensCache, s.cfg.Auth.OfflineURL, s.expectedAuthToken))
 	}
 
 	if s.expectedExitCode == 1 {
@@ -290,8 +290,13 @@ func (s *TodocheckScenario) Run() error {
 	return validationPipeline(validateFuncs...)
 }
 
+func (s *TodocheckScenario) setEnvironmentToken(token string) {
+	s.authTokenEnvVariable = token
+}
+
 func (s *TodocheckScenario) setupTestEnvironment(cmd *exec.Cmd) (teardownFunc, error) {
 	s.setupEnvironmentVariables(cmd, s.envVariables)
+	s.setEnvironmentToken(s.envVariables["TODOCHECK_AUTH_TOKEN"])
 	teardownMockIssueTracker, err := s.setupMockIssueTrackerServer()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't setup mock issue tracker: %w", err)


### PR DESCRIPTION
Removal of setAndPersistToken call and saving the token in memory.
The call mentioned above would always save the token which is not the required behavior.
The token will now be properly cached on ~/todocheck/authtokens.yaml only when it is set in the config file.

Since the TokenCache file will no longer store the token we also need to not run the TokenCache validation test on the scenariobuilder.