### PR TITLE
#138 added a ci step that checks for properly formated golang code

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -7,8 +7,24 @@ on:
       - master
 
 jobs:
+  gofmt-check:
+    name: checking format against gofmt rules
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout new code
+        uses: actions/checkout@v2
+        with: # code from pull request
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+      - name: gofmt test run
+        id: gofmt_run
+        run: |
+          sh ./scripts/gofmt_check.sh
+      - name: gofmt test output
+        run: echo ${{steps.gofmt_run.outputs.gofmt-test}}
   build:
     runs-on: ubuntu-latest
+    needs: gofmt-check
     steps:
       - uses: actions/checkout@v2
         with: # code from pull request
@@ -18,6 +34,7 @@ jobs:
         run: make build
   tests:
     runs-on: ubuntu-latest
+    needs: gofmt-check
     steps:
       - uses: actions/checkout@v2
         with:

--- a/ci-scripts/gofmt_check.sh
+++ b/ci-scripts/gofmt_check.sh
@@ -1,0 +1,11 @@
+GOFMT_TARGETS=$(gofmt -s -l `find . -name '*.go'`)
+
+if [ -n "$GOFMT_TARGETS" ]; then
+    echo "files listed below have not been properly formatted"
+    echo $GOFMT_TARGETS
+    echo ""
+    echo "please make sure you code has been formatted using gofmt"
+    exit 1
+fi
+
+echo "::set-output name=gofmt-test:: step succeed"


### PR DESCRIPTION
tries to solve #138 This action will check for properly formated code based on gofmt rules.
If any files are not already formated then the build and test steps shall not run and the user will be informed for which files have not been formatted as well as a notice to use gofmt.

The issue that was opened requests for the code to be formatted by the ci itself. That required the code to be pushed back on the pull request source( e.g my fork ) which was causing me errors due to access permissions(access tokens).
Thus i came up with this temporary work around. As i was researching for ways to do this i also found a lot of repos doing something similar and also many people mentioning what i described above.