### PR TITLE
Add support for .vue files

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ Based on this, here are the supported languages:
 | R                     | `*.R` extension. Supports single-line `//` comments and multi-line `/* */` comments                                    |
 | Rust                  | `*.rs` extension. Supports single-line `//` comments and multi-line `/* */` comments                                   |
 | Scala                 | `*.scala`, `*.sc` extensions. Supports single-line `//` comments and multi-line `/* */` comments                                 |
-| Swift                 | `*.swift` extension. Supports single-line `//` comments and multi-line `/* */` comments                                |
+| Swift                 | `*.swift` extension. Supports single-line `//` comments and multi-line `/* */` comments
+| Vue                 | `*.vue` extension. Supports single-line `//` comments, multi-line `/* */` comments and multi-line `<!-- -->` HTML comments                                |
 
 If you don't see your favorite language in this table, but it does use one of the supported comment formats, submit an issue [here](https://github.com/preslavmihaylov/todocheck/issues/new)
 

--- a/matchers/matchers.go
+++ b/matchers/matchers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/preslavmihaylov/todocheck/matchers/scripts"
 	"github.com/preslavmihaylov/todocheck/matchers/standard"
 	"github.com/preslavmihaylov/todocheck/matchers/state"
+	"github.com/preslavmihaylov/todocheck/matchers/vue"
 )
 
 // TodoMatcher for todo comments
@@ -124,6 +125,23 @@ var (
 			return groovy.NewCommentMatcher(callback)
 		},
 	}
+
+	vueMatcherFactory = &matcherFactory{
+		func() func([]string) TodoMatcher {
+			var once sync.Once
+			var matcher TodoMatcher
+
+			return func(customTodos []string) TodoMatcher {
+				once.Do(func() {
+					matcher = vue.NewTodoMatcher(customTodos)
+				})
+				return matcher
+			}
+		}(),
+		func(callback state.CommentCallback) CommentMatcher {
+			return vue.NewCommentMatcher(callback)
+		},
+	}
 )
 
 var supportedMatchers = map[string]*matcherFactory{
@@ -159,6 +177,9 @@ var supportedMatchers = map[string]*matcherFactory{
 
 	// file types, supporting python comments
 	".py": pythonMatcherFactory,
+
+	// file types, supporting js, html and css comments
+	".vue": vueMatcherFactory,
 }
 
 // TodoMatcherForFile gets the correct todo matcher for the given filename

--- a/matchers/vue/comments.go
+++ b/matchers/vue/comments.go
@@ -27,7 +27,7 @@ type CommentMatcher struct {
 func (m *CommentMatcher) NonCommentState(
 	filename, line string, linecnt int, prevToken, currToken, nextToken rune,
 ) (state.CommentState, error) {
-	if currToken == '/' && prevToken == '/' {
+	if prevToken == '/' && currToken == '/' {
 		m.buffer += string(currToken)
 
 		return state.SingleLineComment, nil
@@ -35,7 +35,7 @@ func (m *CommentMatcher) NonCommentState(
 		m.stringToken = currToken
 
 		return state.String, nil
-	} else if currToken == '*' && prevToken == '/' {
+	} else if prevToken == '/' && currToken == '*'{
 		m.buffer += string(currToken)
 		m.commentType = "CSS"
 

--- a/matchers/vue/comments.go
+++ b/matchers/vue/comments.go
@@ -35,7 +35,7 @@ func (m *CommentMatcher) NonCommentState(
 		m.stringToken = currToken
 
 		return state.String, nil
-	} else if prevToken == '/' && currToken == '*'{
+	} else if prevToken == '/' && currToken == '*' {
 		m.buffer += string(currToken)
 		m.commentType = "CSS"
 

--- a/matchers/vue/comments.go
+++ b/matchers/vue/comments.go
@@ -1,0 +1,138 @@
+package vue
+
+import (
+	"github.com/preslavmihaylov/todocheck/matchers/state"
+)
+
+// NewCommentMatcher for vue comments
+func NewCommentMatcher(callback state.CommentCallback) *CommentMatcher {
+	return &CommentMatcher{
+		callback: callback,
+	}
+}
+
+// CommentMatcher for vue comments
+type CommentMatcher struct {
+	callback                  state.CommentCallback
+	buffer                    string
+	lines                     []string
+	linecnt                   int
+	stringToken               rune
+	isExitingMultilineComment bool
+	commentType               string
+	isStartingHTML            bool
+}
+
+// NonCommentState for vue comments
+func (m *CommentMatcher) NonCommentState(
+	filename, line string, linecnt int, prevToken, currToken, nextToken rune,
+) (state.CommentState, error) {
+	if currToken == '/' && prevToken == '/' {
+		m.buffer += string(currToken)
+
+		return state.SingleLineComment, nil
+	} else if currToken == '"' || currToken == '\'' {
+		m.stringToken = currToken
+
+		return state.String, nil
+	} else if currToken == '*' && prevToken == '/' {
+		m.buffer += string(currToken)
+		m.commentType = "CSS"
+
+		return state.MultiLineComment, nil
+	} else if prevToken == '<' && currToken == '!' && nextToken == '-' {
+		m.isStartingHTML = true
+
+		return state.NonComment, nil
+	} else if m.isStartingHTML && nextToken == '-' {
+		m.buffer += "<!-"
+		m.commentType = "HTML"
+
+		return state.MultiLineComment, nil
+	} else if m.isStartingHTML && nextToken != '-' {
+		m.isStartingHTML = false
+	}
+
+	return state.NonComment, nil
+}
+
+// StringState for vue comments
+func (m *CommentMatcher) StringState(
+	filename, line string, linecnt int, prevToken, currToken, nextToken rune,
+) (state.CommentState, error) {
+	if prevToken != '\\' && currToken == m.stringToken {
+		return state.NonComment, nil
+	}
+
+	return state.String, nil
+}
+
+// SingleLineCommentState for vue comments
+func (m *CommentMatcher) SingleLineCommentState(
+	filename, line string, linecnt int, prevToken, currToken, nextToken rune,
+) (state.CommentState, error) {
+	if currToken == '\n' {
+		err := m.callback(m.buffer, filename, []string{line}, linecnt)
+		if err != nil {
+			return state.NonComment, err
+		}
+
+		m.resetState()
+		return state.NonComment, nil
+	}
+
+	m.buffer += string(currToken)
+	return state.SingleLineComment, nil
+}
+
+// MultiLineCommentState for vue comments
+func (m *CommentMatcher) MultiLineCommentState(
+	filename, line string, linecnt int, prevToken, currToken, nextToken rune,
+) (state.CommentState, error) {
+	if m.isExitingMultilineComment {
+		m.resetState()
+		return state.NonComment, nil
+	}
+
+	m.buffer += string(currToken)
+	if isEndOfMultilineComment(m.commentType, prevToken, currToken, nextToken) {
+		m.buffer += string(nextToken)
+		err := m.callback(m.buffer, filename, m.lines, m.linecnt)
+		if err != nil {
+			return state.NonComment, err
+		}
+
+		m.isExitingMultilineComment = true
+		return state.MultiLineComment, nil
+	}
+
+	if prevToken == '\n' {
+		m.lines = append(m.lines, line)
+	}
+
+	return state.MultiLineComment, nil
+}
+
+func (m *CommentMatcher) resetState() {
+	m.buffer = ""
+	m.lines = nil
+	m.linecnt = 0
+	m.stringToken = 0
+	m.isExitingMultilineComment = false
+	m.commentType = ""
+	m.isStartingHTML = false
+}
+
+func isEndOfMultilineComment(commentType string, prev, curr, next rune) bool {
+	if commentType == "CSS" {
+		if curr == '*' && next == '/' {
+			return true
+		}
+	}
+	if commentType == "HTML" {
+		if prev == '-' && curr == '-' && next == '>' {
+			return true
+		}
+	}
+	return false
+}

--- a/matchers/vue/doc.go
+++ b/matchers/vue/doc.go
@@ -1,0 +1,3 @@
+// Package vue contains a todo matcher & comments matcher for vue comments.
+// Vue single-line comments use the '//' literal, and the multi-line comments use the CS&JS /**/ or the HTML <!-- --> literals.
+package vue

--- a/matchers/vue/todomatcher.go
+++ b/matchers/vue/todomatcher.go
@@ -11,11 +11,9 @@ import (
 func NewTodoMatcher(todos []string) *TodoMatcher {
 	pattern := common.ArrayAsRegexAnyMatchExpression(todos)
 
-	// Single line
 	singleLineTodoPattern := regexp.MustCompile(`^\s*//.*` + pattern)
 	singleLineValidTodoPattern := regexp.MustCompile(`^\s*// ` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
 
-	// Multiline line
 	multiLineTodoPattern := regexp.MustCompile(`(?s)^\s*(<\!--|/*).*` + pattern)
 	multiLineValidTodoPattern := regexp.MustCompile(`(?s)^\s*(<\!--|/*).*` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
 
@@ -37,7 +35,6 @@ type TodoMatcher struct {
 
 // IsMatch checks if the current expression matches a vue comment
 func (m *TodoMatcher) IsMatch(expr string) bool {
-	//fmt.Println("trying to find match: ", expr)
 	return m.singleLineTodoPattern.Match([]byte(expr)) || m.multiLineTodoPattern.Match([]byte(expr))
 }
 

--- a/matchers/vue/todomatcher.go
+++ b/matchers/vue/todomatcher.go
@@ -1,0 +1,65 @@
+package vue
+
+import (
+	"regexp"
+
+	"github.com/preslavmihaylov/todocheck/common"
+	"github.com/preslavmihaylov/todocheck/matchers/errors"
+)
+
+// NewTodoMatcher for vue comments
+func NewTodoMatcher(todos []string) *TodoMatcher {
+	pattern := common.ArrayAsRegexAnyMatchExpression(todos)
+
+	// Single line
+	singleLineTodoPattern := regexp.MustCompile(`^\s*//.*` + pattern)
+	singleLineValidTodoPattern := regexp.MustCompile(`^\s*// ` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
+
+	// Multiline line
+	multiLineTodoPattern := regexp.MustCompile(`(?s)^\s*(<\!--|/*).*` + pattern)
+	multiLineValidTodoPattern := regexp.MustCompile(`(?s)^\s*(<\!--|/*).*` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
+
+	return &TodoMatcher{
+		singleLineTodoPattern:      singleLineTodoPattern,
+		singleLineValidTodoPattern: singleLineValidTodoPattern,
+		multiLineTodoPattern:       multiLineTodoPattern,
+		multiLineValidTodoPattern:  multiLineValidTodoPattern,
+	}
+}
+
+// TodoMatcher for vue comments
+type TodoMatcher struct {
+	singleLineTodoPattern      *regexp.Regexp
+	singleLineValidTodoPattern *regexp.Regexp
+	multiLineTodoPattern       *regexp.Regexp
+	multiLineValidTodoPattern  *regexp.Regexp
+}
+
+// IsMatch checks if the current expression matches a vue comment
+func (m *TodoMatcher) IsMatch(expr string) bool {
+	//fmt.Println("trying to find match: ", expr)
+	return m.singleLineTodoPattern.Match([]byte(expr)) || m.multiLineTodoPattern.Match([]byte(expr))
+}
+
+// IsValid checks if the expression is a valid todo comment
+func (m *TodoMatcher) IsValid(expr string) bool {
+	return m.singleLineValidTodoPattern.Match([]byte(expr)) || m.multiLineValidTodoPattern.Match([]byte(expr))
+}
+
+// ExtractIssueRef from the given expression.
+// If the expression is invalid, an ErrInvalidTODO is returned
+func (m *TodoMatcher) ExtractIssueRef(expr string) (string, error) {
+	if !m.IsValid(expr) {
+		return "", errors.ErrInvalidTODO
+	}
+
+	singleLineRes := m.singleLineValidTodoPattern.FindStringSubmatch(expr)
+	multiLineRes := m.multiLineValidTodoPattern.FindStringSubmatch(expr)
+	if len(singleLineRes) >= 2 {
+		return singleLineRes[1], nil
+	} else if len(multiLineRes) >= 3 {
+		return multiLineRes[2], nil
+	}
+
+	panic("Invariant violated. No issue reference found in valid TODO")
+}

--- a/testing/scenarios/vue/main.vue
+++ b/testing/scenarios/vue/main.vue
@@ -21,9 +21,9 @@ TODO 4: wellformed HTML multiline entry
 -->
 
 
-"this is a // TODO 1: valid comment in a string"
-"this is a /* TODO 1: valid multiline comment in a string */"
-"this is a <!-- TODO 1: valid HTML multiline comment in a string -->"
+"this is a // TODO 2: valid comment in a string with issue closed"
+"this is a /* TODO 2: valid multiline comment in a string with issue closed */"
+'this is a <!-- TODO 2: valid HTML multiline comment in a string with issue closed -->'
 
 <template>
   <div id="app">

--- a/testing/scenarios/vue/main.vue
+++ b/testing/scenarios/vue/main.vue
@@ -1,7 +1,9 @@
 // oneline comment, malformed TODO
 // TODO 1: oneline comment wellformed
+// TODO 2: oneline comment with Issue closed
 
 <!-- TODO 3: wellformed HTML multiline entry -->
+<!-- TODO 2: wellformed HTML multiline entry, BUT issue closed -->
 <!-- TODO: missing number -->
 
 /* TODO 1: wellformed CS/JS multiline entry */
@@ -10,7 +12,40 @@
 wellformed CS/JS multline entry
 */
 
+/*
+TODO: malformed CS/JS multline entry, missing number
+*/
+
 <!--
 TODO 4: wellformed HTML multiline entry
 -->
 
+
+"this is a // TODO 1: valid comment in a string"
+"this is a /* TODO 1: valid multiline comment in a string */"
+"this is a <!-- TODO 1: valid HTML multiline comment in a string -->"
+
+<template>
+  <div id="app">
+    {{ message }}
+  </div>
+</template> /* TODO 1: valid multiline comment in code */
+
+<script>
+export default {
+  data() {
+    return {
+      message: 'Hello World',
+    };
+  },
+};
+</script> <!-- TODO 1: 
+valid HTML multiline comment in code -->
+
+<style>
+#app {
+  font-size: 18px;
+  font-family: 'Roboto', sans-serif;
+  color: blue; // TODO 2: online comment wellformed in code, BUT issue closed
+}
+</style>

--- a/testing/scenarios/vue/main.vue
+++ b/testing/scenarios/vue/main.vue
@@ -1,0 +1,16 @@
+// oneline comment, malformed TODO
+// TODO 1: oneline comment wellformed
+
+<!-- TODO 3: wellformed HTML multiline entry -->
+<!-- TODO: missing number -->
+
+/* TODO 1: wellformed CS/JS multiline entry */
+/* TODO 2: wellformed CS/JS multiline entry, BUT issue closed */
+/*
+wellformed CS/JS multline entry
+*/
+
+<!--
+TODO 4: wellformed HTML multiline entry
+-->
+

--- a/testing/scenarios/vue/main.vue
+++ b/testing/scenarios/vue/main.vue
@@ -49,3 +49,7 @@ valid HTML multiline comment in code -->
   color: blue; // TODO 2: online comment wellformed in code, BUT issue closed
 }
 </style>
+
+<!--
+TODO : malformed HTML multiline entry
+-->

--- a/testing/todocheck_test.go
+++ b/testing/todocheck_test.go
@@ -765,19 +765,23 @@ func TestVueTodos(t *testing.T) {
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeIssueClosed).
-				WithLocation("scenarios/vue/main.vue", 6)).
+				WithLocation("scenarios/vue/main.vue", 6).
+				ExpectLine("<!-- TODO 2: wellformed HTML multiline entry, BUT issue closed -->")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeMalformed).
-				WithLocation("scenarios/vue/main.vue", 7)).
+				WithLocation("scenarios/vue/main.vue", 7).
+				ExpectLine("<!-- TODO: missing number -->")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeIssueClosed).
-				WithLocation("scenarios/vue/main.vue", 10)).
+				WithLocation("scenarios/vue/main.vue", 10).
+				ExpectLine("/* TODO 2: wellformed CS/JS multiline entry, BUT issue closed */")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeMalformed).
-				WithLocation("scenarios/vue/main.vue", 0).
+				WithLocation("scenarios/vue/main.vue", 15).
+				ExpectLine("/*").
 				ExpectLine("TODO: malformed CS/JS multline entry, missing number").
 				ExpectLine("*/")).
 		ExpectTodoErr(
@@ -785,6 +789,13 @@ func TestVueTodos(t *testing.T) {
 				WithType(errors.TODOErrTypeIssueClosed).
 				WithLocation("scenarios/vue/main.vue", 49).
 				ExpectLine("  color: blue; // TODO 2: online comment wellformed in code, BUT issue closed")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeMalformed).
+				WithLocation("scenarios/vue/main.vue", 53).
+				ExpectLine("<!--").
+				ExpectLine("TODO : malformed HTML multiline entry").
+				ExpectLine("-->")).
 		Run()
 	if err != nil {
 		t.Errorf("%s", err)

--- a/testing/todocheck_test.go
+++ b/testing/todocheck_test.go
@@ -742,6 +742,35 @@ func TestPrintingVersionFlagStopsProgram(t *testing.T) {
 	}
 }
 
+func TestVueTodos(t *testing.T) {
+	err := scenariobuilder.NewScenario().
+		WithBinary("../todocheck").
+		WithBasepath("./scenarios/vue").
+		WithConfig("./test_configs/no_issue_tracker.yaml").
+		WithIssueTracker(issuetracker.Jira).
+		WithIssue("1", issuetracker.StatusOpen).
+		WithIssue("2", issuetracker.StatusClosed).
+		WithIssue("3", issuetracker.StatusOpen).
+		WithIssue("4", issuetracker.StatusOpen).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeMalformed).
+				WithLocation("scenarios/vue/main.vue", 1).
+				ExpectLine("// oneline comment, malformed TODO")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeMalformed).
+				WithLocation("scenarios/vue/main.vue", 5)).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeIssueClosed).
+				WithLocation("scenarios/vue/main.vue", 8)).
+		Run()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+}
+
 // Testing multiple todo matchers created for different file types
 func TestMultipleTodoMatchers(t *testing.T) {
 	err := scenariobuilder.NewScenario().

--- a/testing/todocheck_test.go
+++ b/testing/todocheck_test.go
@@ -759,12 +759,32 @@ func TestVueTodos(t *testing.T) {
 				ExpectLine("// oneline comment, malformed TODO")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
-				WithType(errors.TODOErrTypeMalformed).
-				WithLocation("scenarios/vue/main.vue", 5)).
+				WithType(errors.TODOErrTypeIssueClosed).
+				WithLocation("scenarios/vue/main.vue", 3).
+				ExpectLine("// TODO 2: oneline comment with Issue closed")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeIssueClosed).
-				WithLocation("scenarios/vue/main.vue", 8)).
+				WithLocation("scenarios/vue/main.vue", 6)).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeMalformed).
+				WithLocation("scenarios/vue/main.vue", 7)).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeIssueClosed).
+				WithLocation("scenarios/vue/main.vue", 10)).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeMalformed).
+				WithLocation("scenarios/vue/main.vue", 0).
+				ExpectLine("TODO: malformed CS/JS multline entry, missing number").
+				ExpectLine("*/")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeIssueClosed).
+				WithLocation("scenarios/vue/main.vue", 49).
+				ExpectLine("  color: blue; // TODO 2: online comment wellformed in code, BUT issue closed")).
 		Run()
 	if err != nil {
 		t.Errorf("%s", err)


### PR DESCRIPTION
closes #107 

I added a comment matcher and a todomatcher for .vue-files, supporting oneline JS comments:
`// comment`
as well as multiline JS/CS comments:
`/* comment */`
and HTML comments:
`<!-- comment -->`

I also added some tests for the new file format, and everything seems to work so far.
