### PR TITLE
Functionality to support Azure boards

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -2,8 +2,6 @@ name: master
 
 on:
   push:
-    branches:
-      - master
   pull_request_target:
     branches:
       - master
@@ -52,5 +50,4 @@ jobs:
           TESTS_REDMINE_PRIVATE_APITOKEN: ${{ secrets.TESTS_REDMINE_PRIVATE_APITOKEN }}
           TESTS_YOUTRACK_PUBLIC_INCLOUD_APITOKEN: ${{ secrets.TESTS_YOUTRACK_PUBLIC_INCLOUD_APITOKEN }}
           TESTS_AZUREBOARDS_PRIVATE_APITOKEN: ${{ secrets.TESTS_AZUREBOARDS_PRIVATE_APITOKEN }}
-          TESTS_AZURE_PRIVATE_APITOKEN: ${{ secrets.TESTS_AZURE_PRIVATE_APITOKEN }}
         run: make test

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -2,6 +2,8 @@ name: master
 
 on:
   push:
+    branches:
+      - master
   pull_request_target:
     branches:
       - master
@@ -50,4 +52,5 @@ jobs:
           TESTS_REDMINE_PRIVATE_APITOKEN: ${{ secrets.TESTS_REDMINE_PRIVATE_APITOKEN }}
           TESTS_YOUTRACK_PUBLIC_INCLOUD_APITOKEN: ${{ secrets.TESTS_YOUTRACK_PUBLIC_INCLOUD_APITOKEN }}
           TESTS_AZUREBOARDS_PRIVATE_APITOKEN: ${{ secrets.TESTS_AZUREBOARDS_PRIVATE_APITOKEN }}
+          TESTS_AZURE_PRIVATE_APITOKEN: ${{ secrets.TESTS_AZURE_PRIVATE_APITOKEN }}
         run: make test

--- a/config/issuetracker.go
+++ b/config/issuetracker.go
@@ -46,7 +46,7 @@ var originPatterns = map[IssueTracker]*regexp.Regexp{
 	IssueTrackerPivotal:  regexp.MustCompile(`^(https?://)?(www\.)?pivotaltracker\.com/n/projects/[0-9]+`),
 	IssueTrackerRedmine:  regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9]+)+(:[0-9]+)?$`),
 	IssueTrackerYoutrack: regexp.MustCompile(`^(https?://)?(www\.)?[0-9A-z-]{2,}\/?.*$`),
-	IssueTrackerAzure:    regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-.]+/([a-zA-Z0-9]+)+/([a-zA-Z0-9]+)+.*$`),
+	IssueTrackerAzure:    regexp.MustCompile(`^(https?://)?(www\.)?dev\.azure\.com/([a-zA-Z0-9]+)+\/([a-zA-Z0-9]+)+.*$`),
 }
 
 // IsValid checks if the given issue tracker is among the valid enum values

--- a/config/issuetracker.go
+++ b/config/issuetracker.go
@@ -16,6 +16,7 @@ const (
 	IssueTrackerPivotal               = "PIVOTAL_TRACKER"
 	IssueTrackerRedmine               = "REDMINE"
 	IssueTrackerYoutrack              = "YOUTRACK"
+	IssueTrackerAzure                 = "AZURE"
 )
 
 var ValidIssueTrackerAuthTypes = map[IssueTracker][]AuthType{
@@ -25,6 +26,7 @@ var ValidIssueTrackerAuthTypes = map[IssueTracker][]AuthType{
 	IssueTrackerRedmine:  {AuthTypeNone, AuthTypeAPIToken},
 	IssueTrackerJira:     {AuthTypeNone, AuthTypeOffline},
 	IssueTrackerYoutrack: {AuthTypeAPIToken},
+	IssueTrackerAzure:    {AuthTypeNone, AuthTypeAPIToken},
 }
 
 var validIssueTrackers = []IssueTracker{
@@ -34,6 +36,7 @@ var validIssueTrackers = []IssueTracker{
 	IssueTrackerPivotal,
 	IssueTrackerRedmine,
 	IssueTrackerYoutrack,
+	IssueTrackerAzure,
 }
 
 var originPatterns = map[IssueTracker]*regexp.Regexp{
@@ -43,6 +46,7 @@ var originPatterns = map[IssueTracker]*regexp.Regexp{
 	IssueTrackerPivotal:  regexp.MustCompile(`^(https?://)?(www\.)?pivotaltracker\.com/n/projects/[0-9]+`),
 	IssueTrackerRedmine:  regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9]+)+(:[0-9]+)?$`),
 	IssueTrackerYoutrack: regexp.MustCompile(`^(https?://)?(www\.)?[0-9A-z-]{2,}\/?.*$`),
+	IssueTrackerAzure:    regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-.]+/([a-zA-Z0-9]+)+/([a-zA-Z0-9]+)+.*$`),
 }
 
 // IsValid checks if the given issue tracker is among the valid enum values

--- a/issuetracker/factory/factory.go
+++ b/issuetracker/factory/factory.go
@@ -3,6 +3,8 @@ package factory
 import (
 	"errors"
 
+	"github.com/preslavmihaylov/todocheck/issuetracker/internal/azureboards"
+
 	"github.com/preslavmihaylov/todocheck/config"
 	"github.com/preslavmihaylov/todocheck/issuetracker"
 	"github.com/preslavmihaylov/todocheck/issuetracker/internal/github"
@@ -29,6 +31,8 @@ func NewIssueTrackerFrom(issueTrackerType config.IssueTracker, authCfg *config.A
 		return pivotaltracker.New(origin, authCfg)
 	case config.IssueTrackerYoutrack:
 		return youtrack.New(origin, authCfg)
+	case config.IssueTrackerAzure:
+		return azureboards.New(origin, authCfg)
 	}
 
 	return nil, errors.New("unknown issue tracker " + string(issueTrackerType))

--- a/issuetracker/factory/factory.go
+++ b/issuetracker/factory/factory.go
@@ -32,7 +32,7 @@ func NewIssueTrackerFrom(issueTrackerType config.IssueTracker, authCfg *config.A
 	case config.IssueTrackerYoutrack:
 		return youtrack.New(origin, authCfg)
 	case config.IssueTrackerAzure:
-		return azureboards.New(origin, authCfg)
+		return azureboards.NewIssueTrackerAzure(origin, authCfg)
 	}
 
 	return nil, errors.New("unknown issue tracker " + string(issueTrackerType))

--- a/issuetracker/internal/azureboards/azureboards.go
+++ b/issuetracker/internal/azureboards/azureboards.go
@@ -45,7 +45,7 @@ func (it *IssueTracker) InstrumentMiddleware(r *http.Request) error {
 	// Encode the token with Base64 and append ":". More on: https://bit.ly/35OZ4H8
 	uEnc := base64.URLEncoding.EncodeToString([]byte(":" + it.AuthCfg.Token))
 
-	r.Header.Add("Authorization", "Basic "+ uEnc)
+	r.Header.Add("Authorization", "Basic "+uEnc)
 	return nil
 }
 

--- a/issuetracker/internal/azureboards/azureboards.go
+++ b/issuetracker/internal/azureboards/azureboards.go
@@ -1,0 +1,89 @@
+package azureboards
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/preslavmihaylov/todocheck/common"
+	"github.com/preslavmihaylov/todocheck/config"
+	"github.com/preslavmihaylov/todocheck/issuetracker"
+	"net/http"
+	"strings"
+)
+
+func New(origin string, authCfg *config.Auth) (*IssueTracker, error) {
+	return &IssueTracker{origin, authCfg}, nil
+}
+
+// IssueTracker implementation for integrating with public & private github issue trackers
+type IssueTracker struct {
+	Origin  string
+	AuthCfg *config.Auth
+}
+
+func (it *IssueTracker) TaskModel() issuetracker.Task {
+	return &Task{}
+}
+
+func (it *IssueTracker) IssueURLFor(taskID string) string {
+	return it.issueAPIOrigin() + it.taskURLFrom(taskID)
+}
+
+func (it *IssueTracker) Exists() bool {
+	return true
+}
+
+// InstrumentMiddleware is a hook to instrument any necessary middleware for connecting with the issue tracker
+func (it *IssueTracker) InstrumentMiddleware(r *http.Request) error {
+	if it.AuthCfg == nil || it.AuthCfg.Type == config.AuthTypeNone {
+		return nil
+	} else if it.AuthCfg.Type != config.AuthTypeAPIToken {
+		return fmt.Errorf("unsupported authentication token type for Azure Boards: %s", it.AuthCfg.Type)
+	}
+
+	common.Assert(it.AuthCfg.Token != "", "authentication token is empty")
+
+	// Encode the token with Base64 and append ":". More on: https://bit.ly/35OZ4H8
+	uEnc := base64.URLEncoding.EncodeToString([]byte(":" + it.AuthCfg.Token))
+
+	r.Header.Add("Authorization", "Basic "+ uEnc)
+	return nil
+}
+
+// TokenAcquisitionInstructions returns instructions for manually acquiring the authentication token
+// for github and the given authentication type
+func (it *IssueTracker) TokenAcquisitionInstructions() string {
+	if it.AuthCfg.Type == config.AuthTypeNone {
+		return ""
+	}
+
+	return "Please create a read-only access token at Microsoft Azure & paste it here."
+}
+
+// taskURLFrom taskID returns the url for the target github task ID to fetch
+func (it *IssueTracker) taskURLFrom(taskID string) string {
+	if strings.HasPrefix(taskID, "#") {
+		return taskID[1:]
+	}
+	// TODO Remove hardcoded API version. Make it configurable through yaml
+	return fmt.Sprintf("/%s?api-version=6.0", taskID)
+}
+
+// issueAPIOrigin returns the URL for github's issue-fetching API
+func (it *IssueTracker) issueAPIOrigin() string {
+	return fmt.Sprintf("%s/_apis/wit/workitems", it.repositoryURL())
+}
+
+func (it *IssueTracker) repositoryURL() string {
+	scheme, owner, repo := it.urlTokensFromOrigin()
+	return fmt.Sprintf("%s//dev.azure.com/%s/%s", scheme, owner, repo)
+
+}
+
+func (it *IssueTracker) urlTokensFromOrigin() (scheme, owner, repo string) {
+	tokens := common.RemoveEmptyTokens(strings.Split(strings.ToLower(it.Origin), "/"))
+	if !strings.HasPrefix(tokens[0], "http") {
+		tokens = append([]string{"https:"}, tokens...)
+	}
+	scheme, owner, repo = tokens[0], tokens[2], tokens[3]
+	return
+}

--- a/issuetracker/internal/azureboards/azureboards.go
+++ b/issuetracker/internal/azureboards/azureboards.go
@@ -11,8 +11,8 @@ import (
 	"github.com/preslavmihaylov/todocheck/issuetracker"
 )
 
-const supportedAPIVersion = 6.0
-const tokenAcquisitionURL = "https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=preview-page"
+const supportedAPIVersion = "6.0"
+const tokenAcquisitionURL = "https://bit.ly/3wxUbNF"
 
 func NewIssueTrackerAzure(origin string, authCfg *config.Auth) (*IssueTracker, error) {
 	return &IssueTracker{origin, authCfg}, nil
@@ -68,7 +68,7 @@ func (it *IssueTracker) taskURLFrom(taskID string) string {
 	if strings.HasPrefix(taskID, "#") {
 		return taskID[1:]
 	}
-	return fmt.Sprintf("/%s?api-version=%.1f", taskID, supportedAPIVersion)
+	return fmt.Sprintf("/%s?api-version=%s", taskID, supportedAPIVersion)
 }
 
 // issueAPIOrigin returns the URL for Azure Boards' issue-fetching API
@@ -77,13 +77,13 @@ func (it *IssueTracker) issueAPIOrigin() string {
 }
 
 func (it *IssueTracker) repositoryURL() string {
-	scheme, owner, repo := it.urlTokensFromOrigin()
+	scheme, owner, repo := it.urlTokensFromOrigin(it.Origin)
 	return fmt.Sprintf("%s//dev.azure.com/%s/%s", scheme, owner, repo)
 
 }
 
-func (it *IssueTracker) urlTokensFromOrigin() (scheme, owner, repo string) {
-	tokens := common.RemoveEmptyTokens(strings.Split(strings.ToLower(it.Origin), "/"))
+func (it *IssueTracker) urlTokensFromOrigin(origin string) (scheme, owner, repo string) {
+	tokens := common.RemoveEmptyTokens(strings.Split(strings.ToLower(origin), "/"))
 	if !strings.HasPrefix(tokens[0], "http") {
 		tokens = append([]string{"https:"}, tokens...)
 	}

--- a/issuetracker/internal/azureboards/azureboards_test.go
+++ b/issuetracker/internal/azureboards/azureboards_test.go
@@ -8,19 +8,20 @@ import (
 func Test_IssueTracker_IssueURLFor(t *testing.T) {
 
 	var tests = []struct {
-		input  string
-		taskID string
-		want   string
+		testName string
+		input    string
+		taskID   string
+		want     string
 	}{
-		{"https://dev.azure.com/todoerruser/todocheck", "1", "https://dev.azure.com/todoerruser/todocheck/_apis/wit/workitems/1?api-version=6.0"},
-		{"https://dev.azure.com/123foo998!/thebigproject", "2", "https://dev.azure.com/123foo998!/thebigproject/_apis/wit/workitems/2?api-version=6.0"},
-		{"dev.azure.com/todoerruser/todocheck", "225", "https://dev.azure.com/todoerruser/todocheck/_apis/wit/workitems/225?api-version=6.0"},
-		{"dev.azure.com/foo.bar/quixproject", "123", "https://dev.azure.com/foo.bar/quixproject/_apis/wit/workitems/123?api-version=6.0"},
+		{"URL without special symbols", "https://dev.azure.com/todoerruser/todocheck", "1", "https://dev.azure.com/todoerruser/todocheck/_apis/wit/workitems/1?api-version=6.0"},
+		{"URL with special symbols", "https://dev.azure.com/123foo998!/thebigproject123.", "2", "https://dev.azure.com/123foo998!/thebigproject123./_apis/wit/workitems/2?api-version=6.0"},
+		{"URL without https prefix", "dev.azure.com/todoerruser/todocheck", "225", "https://dev.azure.com/todoerruser/todocheck/_apis/wit/workitems/225?api-version=6.0"},
+		{"URL with special symbol in username", "dev.azure.com/foo.bar/quixproject", "123", "https://dev.azure.com/foo.bar/quixproject/_apis/wit/workitems/123?api-version=6.0"},
 	}
 	for _, tt := range tests {
 		var it IssueTracker
 
-		testname := fmt.Sprintf("%q", tt.input)
+		testname := fmt.Sprintf("%q", tt.testName)
 		t.Run(testname, func(t *testing.T) {
 			it.Origin = tt.input
 			res := it.IssueURLFor(tt.taskID)

--- a/issuetracker/internal/azureboards/azureboards_test.go
+++ b/issuetracker/internal/azureboards/azureboards_test.go
@@ -1,0 +1,33 @@
+package azureboards
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_IssueTracker_IssueURLFor(t *testing.T) {
+
+	var tests = []struct {
+		input  string
+		taskID string
+		want   string
+	}{
+		{"https://dev.azure.com/todoerruser/todocheck", "1", "https://dev.azure.com/todoerruser/todocheck/_apis/wit/workitems/1?api-version=6.0"},
+		{"https://dev.azure.com/123foo998!/thebigproject", "2", "https://dev.azure.com/123foo998!/thebigproject/_apis/wit/workitems/2?api-version=6.0"},
+		{"dev.azure.com/todoerruser/todocheck", "225", "https://dev.azure.com/todoerruser/todocheck/_apis/wit/workitems/225?api-version=6.0"},
+		{"dev.azure.com/foo.bar/quixproject", "123", "https://dev.azure.com/foo.bar/quixproject/_apis/wit/workitems/123?api-version=6.0"},
+	}
+	for _, tt := range tests {
+		var it IssueTracker
+
+		testname := fmt.Sprintf("%q", tt.input)
+		t.Run(testname, func(t *testing.T) {
+			it.Origin = tt.input
+			res := it.IssueURLFor(tt.taskID)
+			if res != tt.want {
+				t.Errorf("got %s, want %s", res, tt.want)
+			}
+		})
+	}
+
+}

--- a/issuetracker/internal/azureboards/task.go
+++ b/issuetracker/internal/azureboards/task.go
@@ -1,6 +1,10 @@
 package azureboards
 
-import "github.com/preslavmihaylov/todocheck/issuetracker/taskstatus"
+import (
+	"fmt"
+
+	"github.com/preslavmihaylov/todocheck/issuetracker/taskstatus"
+)
 
 // Task model
 type Task struct {
@@ -12,9 +16,8 @@ type Task struct {
 
 // GetStatus of github task, based on underlying structure
 func (t *Task) GetStatus() taskstatus.TaskStatus {
+	fmt.Printf(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>Got state %s", t.Fields.State)
 	switch t.Fields.State {
-	case "To Do":
-		fallthrough
 	case "Done":
 		return taskstatus.Closed
 	default:

--- a/issuetracker/internal/azureboards/task.go
+++ b/issuetracker/internal/azureboards/task.go
@@ -1,8 +1,6 @@
 package azureboards
 
 import (
-	"fmt"
-
 	"github.com/preslavmihaylov/todocheck/issuetracker/taskstatus"
 )
 
@@ -16,7 +14,6 @@ type Task struct {
 
 // GetStatus of github task, based on underlying structure
 func (t *Task) GetStatus() taskstatus.TaskStatus {
-	fmt.Printf(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>Got state %s", t.Fields.State)
 	switch t.Fields.State {
 	case "Done":
 		return taskstatus.Closed

--- a/issuetracker/internal/azureboards/task.go
+++ b/issuetracker/internal/azureboards/task.go
@@ -4,13 +4,18 @@ import "github.com/preslavmihaylov/todocheck/issuetracker/taskstatus"
 
 // Task model
 type Task struct {
-	State string `json:"state"`
+	ID     int `json:"id"`
+	Fields struct {
+		State string `json:"System.State"`
+	}
 }
 
 // GetStatus of github task, based on underlying structure
 func (t *Task) GetStatus() taskstatus.TaskStatus {
-	switch t.State {
-	case "closed":
+	switch t.Fields.State {
+	case "To Do":
+		fallthrough
+	case "Done":
 		return taskstatus.Closed
 	default:
 		return taskstatus.Open

--- a/issuetracker/internal/azureboards/task.go
+++ b/issuetracker/internal/azureboards/task.go
@@ -1,0 +1,18 @@
+package azureboards
+
+import "github.com/preslavmihaylov/todocheck/issuetracker/taskstatus"
+
+// Task model
+type Task struct {
+	State string `json:"state"`
+}
+
+// GetStatus of github task, based on underlying structure
+func (t *Task) GetStatus() taskstatus.TaskStatus {
+	switch t.State {
+	case "closed":
+		return taskstatus.Closed
+	default:
+		return taskstatus.Open
+	}
+}

--- a/testing/integrations_test.go
+++ b/testing/integrations_test.go
@@ -184,7 +184,7 @@ func TestPublicAzureIntegration(t *testing.T) {
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeMalformed).
 				WithLocation("scenarios/integrations/azureboards_public/main.go", 3).
-				ExpectLine("// TODO: MALFORMED Issue")).
+				ExpectLine("// TODO MALFORMED Issue")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeNonExistentIssue).

--- a/testing/integrations_test.go
+++ b/testing/integrations_test.go
@@ -187,6 +187,11 @@ func TestPublicAzureIntegration(t *testing.T) {
 				ExpectLine("// TODO MALFORMED Issue")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeIssueClosed).
+				WithLocation("scenarios/integrations/azureboards_private/main.go", 6).
+				ExpectLine("// TODO 3: An issue in CLOSED column")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeNonExistentIssue).
 				WithLocation("scenarios/integrations/azureboards_public/main.go", 7).
 				ExpectLine("// TODO 12345: A non-existent issue")).
@@ -208,6 +213,11 @@ func TestPrivateAzureIntegration(t *testing.T) {
 				WithType(errors.TODOErrTypeMalformed).
 				WithLocation("scenarios/integrations/azureboards_private/main.go", 3).
 				ExpectLine("// TODO: 1 A malformed issue")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeNonExistentIssue).
+				WithLocation("scenarios/integrations/azureboards_private/main.go", 5).
+				ExpectLine("// TODO 9: An issue in CLOSED column")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeNonExistentIssue).

--- a/testing/integrations_test.go
+++ b/testing/integrations_test.go
@@ -174,6 +174,51 @@ func TestPrivateRedmineIntegration(t *testing.T) {
 	}
 }
 
+func TestPublicAzureIntegration(t *testing.T) {
+	err := scenariobuilder.NewScenario().
+		OnlyRunOnCI().
+		WithBinary("../todocheck").
+		WithBasepath("./scenarios/integrations/azureboards_public").
+		WithConfig("./test_configs/integrations/azureboards_public.yaml").
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeMalformed).
+				WithLocation("./scenarios/integrations/azureboards_public/main.go", 3).
+				ExpectLine("// TODO: 1 A malformed issue")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeNonExistentIssue).
+				WithLocation("./scenarios/integrations/azureboards_public/main.go", 7).
+				ExpectLine("// TODO 999: A non-existent issue")).
+		Run()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+}
+
+func TestPrivateAzureIntegration(t *testing.T) {
+	err := scenariobuilder.NewScenario().
+		OnlyRunOnCI().
+		WithAuthTokenFromEnv("TESTS_AZURE_PRIVATE_APITOKEN").
+		WithBinary("../todocheck").
+		WithBasepath("./scenarios/integrations/azureboards_private").
+		WithConfig("./test_configs/integrations/azureboards_private.yaml").
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeMalformed).
+				WithLocation("./scenarios/integrations/azureboards_private/main.go", 3).
+				ExpectLine("// TODO: 1 A malformed issue")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeNonExistentIssue).
+				WithLocation("./scenarios/integrations/azureboards_private/main.go", 7).
+				ExpectLine("// TODO 999: A non-existent issue")).
+		Run()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+}
+
 func baseGithubScenario() *scenariobuilder.TodocheckScenario {
 	return scenariobuilder.NewScenario().
 		WithBinary("../todocheck").

--- a/testing/integrations_test.go
+++ b/testing/integrations_test.go
@@ -188,7 +188,7 @@ func TestPublicAzureIntegration(t *testing.T) {
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeIssueClosed).
-				WithLocation("scenarios/integrations/azureboards_private/main.go", 6).
+				WithLocation("scenarios/integrations/azureboards_public/main.go", 6).
 				ExpectLine("// TODO 3: An issue in CLOSED column")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().

--- a/testing/integrations_test.go
+++ b/testing/integrations_test.go
@@ -215,7 +215,7 @@ func TestPrivateAzureIntegration(t *testing.T) {
 				ExpectLine("// TODO: 1 A malformed issue")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
-				WithType(errors.TODOErrTypeNonExistentIssue).
+				WithType(errors.TODOErrTypeIssueClosed).
 				WithLocation("scenarios/integrations/azureboards_private/main.go", 5).
 				ExpectLine("// TODO 9: An issue in CLOSED column")).
 		ExpectTodoErr(

--- a/testing/integrations_test.go
+++ b/testing/integrations_test.go
@@ -183,12 +183,12 @@ func TestPublicAzureIntegration(t *testing.T) {
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeMalformed).
-				WithLocation("./scenarios/integrations/azureboards_public/main.go", 3).
+				WithLocation("scenarios/integrations/azureboards_public/main.go", 3).
 				ExpectLine("// TODO: 1 A malformed issue")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeNonExistentIssue).
-				WithLocation("./scenarios/integrations/azureboards_public/main.go", 7).
+				WithLocation("scenarios/integrations/azureboards_public/main.go", 7).
 				ExpectLine("// TODO 999: A non-existent issue")).
 		Run()
 	if err != nil {
@@ -206,12 +206,12 @@ func TestPrivateAzureIntegration(t *testing.T) {
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeMalformed).
-				WithLocation("./scenarios/integrations/azureboards_private/main.go", 3).
+				WithLocation("scenarios/integrations/azureboards_private/main.go", 3).
 				ExpectLine("// TODO: 1 A malformed issue")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeNonExistentIssue).
-				WithLocation("./scenarios/integrations/azureboards_private/main.go", 7).
+				WithLocation("scenarios/integrations/azureboards_private/main.go", 7).
 				ExpectLine("// TODO 999: A non-existent issue")).
 		Run()
 	if err != nil {

--- a/testing/integrations_test.go
+++ b/testing/integrations_test.go
@@ -184,7 +184,7 @@ func TestPublicAzureIntegration(t *testing.T) {
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeMalformed).
 				WithLocation("scenarios/integrations/azureboards_public/main.go", 3).
-				ExpectLine("// TODO: 1 A malformed issue")).
+				ExpectLine("// TODO MALFORMED: Issue")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeNonExistentIssue).

--- a/testing/integrations_test.go
+++ b/testing/integrations_test.go
@@ -184,12 +184,12 @@ func TestPublicAzureIntegration(t *testing.T) {
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeMalformed).
 				WithLocation("scenarios/integrations/azureboards_public/main.go", 3).
-				ExpectLine("// TODO: 1 A malformed issue")).
+				ExpectLine("// TODO: MALFORMED Issue")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeNonExistentIssue).
 				WithLocation("scenarios/integrations/azureboards_public/main.go", 7).
-				ExpectLine("// TODO 999: A non-existent issue")).
+				ExpectLine("// TODO 12345: A non-existent issue")).
 		Run()
 	if err != nil {
 		t.Errorf("%s", err)

--- a/testing/integrations_test.go
+++ b/testing/integrations_test.go
@@ -184,7 +184,7 @@ func TestPublicAzureIntegration(t *testing.T) {
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeMalformed).
 				WithLocation("scenarios/integrations/azureboards_public/main.go", 3).
-				ExpectLine("// TODO MALFORMED: Issue")).
+				ExpectLine("// TODO: 1 A malformed issue")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeNonExistentIssue).

--- a/testing/integrations_test.go
+++ b/testing/integrations_test.go
@@ -199,7 +199,7 @@ func TestPublicAzureIntegration(t *testing.T) {
 func TestPrivateAzureIntegration(t *testing.T) {
 	err := scenariobuilder.NewScenario().
 		OnlyRunOnCI().
-		WithAuthTokenFromEnv("TESTS_AZURE_PRIVATE_APITOKEN").
+		WithAuthTokenFromEnv("TESTS_AZUREBOARDS_PRIVATE_APITOKEN").
 		WithBinary("../todocheck").
 		WithBasepath("./scenarios/integrations/azureboards_private").
 		WithConfig("./test_configs/integrations/azureboards_private.yaml").

--- a/testing/scenarios/integrations/azureboards_private/main.go
+++ b/testing/scenarios/integrations/azureboards_private/main.go
@@ -1,0 +1,7 @@
+package main
+
+// TODO: 1 A malformed issue
+// TODO 4: An issue in DOING columng
+// TODO 5: An issue in CLOSED column
+// TODO 6: An issue in TODO column
+// TODO 999: A non-existent issue

--- a/testing/scenarios/integrations/azureboards_private/main.go
+++ b/testing/scenarios/integrations/azureboards_private/main.go
@@ -1,7 +1,7 @@
 package main
 
 // TODO: 1 A malformed issue
-// TODO 4: An issue in DOING columng
+// TODO 4: An issue in DOING column
 // TODO 5: An issue in CLOSED column
 // TODO 6: An issue in TODO column
 // TODO 999: A non-existent issue

--- a/testing/scenarios/integrations/azureboards_private/main.go
+++ b/testing/scenarios/integrations/azureboards_private/main.go
@@ -1,7 +1,7 @@
 package main
 
 // TODO: 1 A malformed issue
-// TODO 4: An issue in DOING column
-// TODO 5: An issue in CLOSED column
-// TODO 6: An issue in TODO column
+// TODO 8: An issue in DOING column
+// TODO 9: An issue in CLOSED column
+// TODO 7: An issue in TODO column
 // TODO 999: A non-existent issue

--- a/testing/scenarios/integrations/azureboards_public/main.go
+++ b/testing/scenarios/integrations/azureboards_public/main.go
@@ -1,6 +1,6 @@
 package main
 
-// TODO MALFORMED: Issue
+// TODO MALFORMED Issue
 // TODO 6: An issue in TODO column
 // TODO 4: An issue in DOING column
 // TODO 3: An issue in CLOSED column

--- a/testing/scenarios/integrations/azureboards_public/main.go
+++ b/testing/scenarios/integrations/azureboards_public/main.go
@@ -1,0 +1,6 @@
+package main
+
+// TODO 7: An issue in TODO columng
+// TODO 8: An issue in DOING column
+// TODO 9: An issue in CLOSED column
+// TODO 12345: A non-existent issue

--- a/testing/scenarios/integrations/azureboards_public/main.go
+++ b/testing/scenarios/integrations/azureboards_public/main.go
@@ -1,6 +1,6 @@
 package main
 
-// TODO 7: An issue in TODO columng
+// TODO 7: An issue in TODO column
 // TODO 8: An issue in DOING column
 // TODO 9: An issue in CLOSED column
 // TODO 12345: A non-existent issue

--- a/testing/scenarios/integrations/azureboards_public/main.go
+++ b/testing/scenarios/integrations/azureboards_public/main.go
@@ -1,5 +1,6 @@
 package main
 
+// TODO MALFORMED: Issue
 // TODO 6: An issue in TODO column
 // TODO 4: An issue in DOING column
 // TODO 3: An issue in CLOSED column

--- a/testing/scenarios/integrations/azureboards_public/main.go
+++ b/testing/scenarios/integrations/azureboards_public/main.go
@@ -1,6 +1,6 @@
 package main
 
-// TODO 7: An issue in TODO column
-// TODO 8: An issue in DOING column
-// TODO 9: An issue in CLOSED column
+// TODO 6: An issue in TODO column
+// TODO 4: An issue in DOING column
+// TODO 3: An issue in CLOSED column
 // TODO 12345: A non-existent issue

--- a/testing/test_configs/integrations/azureboards_private.yaml
+++ b/testing/test_configs/integrations/azureboards_private.yaml
@@ -1,4 +1,4 @@
-origin: https://dev.azureboards.com/todoerruser/private_todocheck
+origin: https://dev.azure.com/todoerruser/private_todocheck
 issue_tracker: AZURE
 auth:
   type: apitoken

--- a/testing/test_configs/integrations/azureboards_private.yaml
+++ b/testing/test_configs/integrations/azureboards_private.yaml
@@ -1,0 +1,4 @@
+origin: https://dev.azureboards.com/todoerruser/private_todocheck
+issue_tracker: AZURE
+auth:
+  type: apitoken

--- a/testing/test_configs/integrations/azureboards_public.yaml
+++ b/testing/test_configs/integrations/azureboards_public.yaml
@@ -1,0 +1,2 @@
+origin: https://dev.azureboards.com/todoerruser/todocheck/
+issue_tracker: AZURE

--- a/testing/test_configs/integrations/azureboards_public.yaml
+++ b/testing/test_configs/integrations/azureboards_public.yaml
@@ -1,2 +1,2 @@
-origin: https://dev.azureboards.com/todoerruser/todocheck/
+origin: https://dev.azure.com/todoerruser/todocheck/
 issue_tracker: AZURE


### PR DESCRIPTION
Add Azure issue tracker in config

Add Azure issue tracker to factory

Add support for Microsoft Azure boards

Remove redundant print; Add comments

Add unit tests for Azure boards

Cleanup; fix indentation

Add Azure boards public and private example yaml definitions for integration tests.

Add example test file for integrations test

Add Azure integration test scenario.

enable CI on push to master

Apply gofmt

Add base 64 encoding to support token auth for Microsoft Azure.

Update integration tests

Add example file in order to have something to assert against.
Split Azure example files in two folders