### PR TITLE
Add support for all Kotlin files

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Based on this, here are the supported languages:
 | Groovy                | `*.groovy`, `*.gvy`, `*.gy`, `*.gsh` extensions. Supports single-line `//` comments and multi-line `/* */` comments    |
 | Java                  | `*.java` extension. Supports single-line `//` comments and multi-line `/* */` comments                                 |
 | JavaScript/Typescript | `*.js/*.ts` extension. Supports single-line `//` comments and multi-line `/* */` comments                              |
+| Kotlin                | `*.kt/*.kts/*.ktm` extension. Supports single-line `//` comments and multi-line `/* */` comments                              |
 | PHP                   | `*.php` extension. Supports single-line `#` and `//` comments and multi-line `/* */` comments                          |
 | Python                | `*.py` extension. Supports single-line `#` comments and multi-line `"""` comments                                      |
 | R                     | `*.R` extension. Supports single-line `//` comments and multi-line `/* */` comments                                    |

--- a/matchers/matchers.go
+++ b/matchers/matchers.go
@@ -155,6 +155,9 @@ var supportedMatchers = map[string]*matcherFactory{
 	".ts":   standardMatcherFactory,
 
 	// file types, supporting standard comments \w nested multi-line comments
+	".kt":    standardMatcherWithNestedMultilineCommentsFactory,
+	".kts":   standardMatcherWithNestedMultilineCommentsFactory,
+	".ktm":   standardMatcherWithNestedMultilineCommentsFactory,
 	".rs":    standardMatcherWithNestedMultilineCommentsFactory,
 	".swift": standardMatcherWithNestedMultilineCommentsFactory,
 	".scala": standardMatcherWithNestedMultilineCommentsFactory,

--- a/testing/scenarios/swift/main.kt
+++ b/testing/scenarios/swift/main.kt
@@ -1,0 +1,7 @@
+/* TODO 1: Add Spring dependencies (open issue) */
+// TODO 2: This one is closed though
+
+fun main() {
+/* TODO: 3 /* Document main, because it's magic (and this is malformed) */ */
+
+}

--- a/testing/scenarios/swift/main.rs
+++ b/testing/scenarios/swift/main.rs
@@ -1,0 +1,7 @@
+// TODO 1: Open issue
+
+/* TODO 2: Closed issue */
+
+// This is a malformed TODO
+
+/* This is /* another malformed */ TODO 3 */

--- a/testing/todocheck_test.go
+++ b/testing/todocheck_test.go
@@ -647,6 +647,15 @@ func TestSwiftTodos(t *testing.T) {
 			WithType(errors.TODOErrTypeMalformed).
 			WithLocation("scenarios/swift/main.rs", 7).
 			ExpectLine("/* This is /* another malformed */ TODO 3 */")).
+		// Kotlin
+		ExpectTodoErr(scenariobuilder.NewTodoErr().
+			WithType(errors.TODOErrTypeIssueClosed).
+			WithLocation("scenarios/swift/main.kt", 2).
+			ExpectLine("// TODO 2: This one is closed though")).
+		ExpectTodoErr(scenariobuilder.NewTodoErr().
+			WithType(errors.TODOErrTypeMalformed).
+			WithLocation("scenarios/swift/main.kt", 5).
+			ExpectLine("/* TODO: 3 /* Document main, because it's magic (and this is malformed) */ */")).
 		Run()
 	if err != nil {
 		t.Errorf("%s", err)

--- a/testing/todocheck_test.go
+++ b/testing/todocheck_test.go
@@ -591,7 +591,7 @@ func TestGroovyTodos(t *testing.T) {
 	}
 }
 
-// Also tests Rust TODOs as rust uses the same comment syntax
+// Also tests Rust and Kotlin TODOs as they use the same comment syntax
 func TestSwiftTodos(t *testing.T) {
 	err := scenariobuilder.NewScenario().
 		WithBinary("../todocheck").

--- a/testing/todocheck_test.go
+++ b/testing/todocheck_test.go
@@ -600,6 +600,7 @@ func TestSwiftTodos(t *testing.T) {
 		WithIssueTracker(issuetracker.Jira).
 		WithIssue("1", issuetracker.StatusOpen).
 		WithIssue("2", issuetracker.StatusClosed).
+		// Swift
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeMalformed).
@@ -633,6 +634,19 @@ func TestSwiftTodos(t *testing.T) {
 				ExpectLine("    /* TODO 2: invalid todo as issue is closed */").
 				ExpectLine(" */").
 				ExpectLine("*/")).
+		// Rust
+		ExpectTodoErr(scenariobuilder.NewTodoErr().
+			WithType(errors.TODOErrTypeIssueClosed).
+			WithLocation("scenarios/swift/main.rs", 3).
+			ExpectLine("/* TODO 2: Closed issue */")).
+		ExpectTodoErr(scenariobuilder.NewTodoErr().
+			WithType(errors.TODOErrTypeMalformed).
+			WithLocation("scenarios/swift/main.rs", 5).
+			ExpectLine("// This is a malformed TODO")).
+		ExpectTodoErr(scenariobuilder.NewTodoErr().
+			WithType(errors.TODOErrTypeMalformed).
+			WithLocation("scenarios/swift/main.rs", 7).
+			ExpectLine("/* This is /* another malformed */ TODO 3 */")).
 		Run()
 	if err != nil {
 		t.Errorf("%s", err)


### PR DESCRIPTION
Closes #155.

Reuses the standard comment matcher used for Rust and Swift, which supports single-, multiline comments, as well as nested comments.