### PR TITLE
Nim Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Based on this, here are the supported languages:
 | Java                  | `*.java` extension. Supports single-line `//` comments and multi-line `/* */` comments                                 |
 | JavaScript/Typescript | `*.js/*.ts` extension. Supports single-line `//` comments and multi-line `/* */` comments                              |
 | Kotlin                | `*.kt/*.kts/*.ktm` extension. Supports single-line `//` comments and multi-line `/* */` comments                              |
+| Nim                   | `*.{nim, nims, nimble}` extension. Supports single-line `#` comments and multi-line `#[ ]#` comments                          |
 | PHP                   | `*.php` extension. Supports single-line `#` and `//` comments and multi-line `/* */` comments                          |
 | Python                | `*.py` extension. Supports single-line `#` comments and multi-line `"""` comments                                      |
 | R                     | `*.R` extension. Supports single-line `//` comments and multi-line `/* */` comments                                    |

--- a/matchers/matchers.go
+++ b/matchers/matchers.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/preslavmihaylov/todocheck/matchers/groovy"
+	"github.com/preslavmihaylov/todocheck/matchers/nim"
 	"github.com/preslavmihaylov/todocheck/matchers/php"
 	"github.com/preslavmihaylov/todocheck/matchers/python"
 	"github.com/preslavmihaylov/todocheck/matchers/scripts"
@@ -125,7 +126,6 @@ var (
 			return groovy.NewCommentMatcher(callback)
 		},
 	}
-
 	vueMatcherFactory = &matcherFactory{
 		func() func([]string) TodoMatcher {
 			var once sync.Once
@@ -140,6 +140,22 @@ var (
 		}(),
 		func(callback state.CommentCallback) CommentMatcher {
 			return vue.NewCommentMatcher(callback)
+		},
+	}
+	nimMatcherFactory = &matcherFactory{
+		func() func([]string) TodoMatcher {
+			var once sync.Once
+			var matcher TodoMatcher
+
+			return func(customTodos []string) TodoMatcher {
+				once.Do(func() {
+					matcher = nim.NewTodoMatcher(customTodos)
+				})
+				return matcher
+			}
+		}(),
+		func(callback state.CommentCallback) CommentMatcher {
+			return nim.NewCommentMatcher(callback)
 		},
 	}
 )
@@ -183,6 +199,9 @@ var supportedMatchers = map[string]*matcherFactory{
 
 	// file types, supporting js, html and css comments
 	".vue": vueMatcherFactory,
+
+	// file types, supporting nim comments
+	".nim": nimMatcherFactory,
 }
 
 // TodoMatcherForFile gets the correct todo matcher for the given filename

--- a/matchers/matchers.go
+++ b/matchers/matchers.go
@@ -201,7 +201,9 @@ var supportedMatchers = map[string]*matcherFactory{
 	".vue": vueMatcherFactory,
 
 	// file types, supporting nim comments
-	".nim": nimMatcherFactory,
+	".nim":    nimMatcherFactory,
+	".nims":   nimMatcherFactory,
+	".nimble": nimMatcherFactory,
 }
 
 // TodoMatcherForFile gets the correct todo matcher for the given filename

--- a/matchers/nim/comments.go
+++ b/matchers/nim/comments.go
@@ -1,0 +1,129 @@
+package nim
+
+import "github.com/preslavmihaylov/todocheck/matchers/state"
+
+func NewCommentMatcher(callback state.CommentCallback) *CommentMatcher {
+	return &CommentMatcher{
+		callback: callback,
+		depth:    1,
+	}
+}
+
+type CommentMatcher struct {
+	callback    state.CommentCallback
+	buffer      string
+	lines       []string
+	lineCount   int
+	stringToken rune
+
+	depth int
+}
+
+func (m *CommentMatcher) NonCommentState(
+	filename,
+	line string,
+	lineCnt int,
+	prevToken, currToken, nextToken rune,
+) (state.CommentState, error) {
+	if isSingleLineOpener(currToken, nextToken) {
+		// Catch single line comments
+		m.buffer += string(currToken)
+		return state.SingleLineComment, nil
+	} else if isMultiLineOpener(currToken, nextToken) {
+		// Catch multi line comments
+		m.buffer += string(currToken)
+		m.lines = []string{line}
+		m.lineCount = lineCnt
+		return state.MultiLineComment, nil
+	} else if currToken == '"' || currToken == '\'' || currToken == '`' {
+		m.stringToken = currToken
+		return state.String, nil
+	} else {
+		m.buffer += string(currToken)
+		return state.SingleLineComment, nil
+	}
+}
+
+func (m *CommentMatcher) MultiLineCommentState(
+	filename, line string, linecnt int, prevToken, currToken, nextToken rune,
+) (state.CommentState, error) {
+	m.buffer += string(currToken)
+
+	if isMultiLineOpener(currToken, nextToken) {
+		// Capture nested comments
+		m.depth += 1
+	} else if isMultiLineCloser(currToken, nextToken) {
+		if m.depth > 1 {
+			// Decrease nesting
+			m.depth -= 1
+		} else {
+			// depth is at 1, this is a real comment closer
+			err := m.callback(m.buffer, filename, m.lines, m.lineCount)
+			if err != nil {
+				return state.NonComment, err
+			}
+
+			m.buffer = ""
+			m.lines = nil
+			m.lineCount = 0
+			m.stringToken = 0
+			m.depth = 1
+
+			return state.NonComment, nil
+		}
+	}
+
+	if prevToken == '\n' {
+		m.lines = append(m.lines, line)
+	}
+
+	return state.MultiLineComment, nil
+}
+
+func (m *CommentMatcher) SingleLineCommentState(
+	filename, line string, linecnt int, prevToken, currToken, nextToken rune,
+) (state.CommentState, error) {
+	if currToken == '\n' {
+		// Reach end of line i.e. end of comment
+		err := m.callback(m.buffer, filename, []string{line}, linecnt)
+		if err != nil {
+			return state.NonComment, err
+		}
+
+		m = &CommentMatcher{
+			callback:    m.callback,
+			buffer:      "",
+			lines:       nil,
+			lineCount:   0,
+			stringToken: 0,
+			depth:       1,
+		}
+		return state.NonComment, nil
+	}
+
+	m.buffer += string(currToken)
+	return state.SingleLineComment, nil
+}
+
+// StringState for standard comments
+func (m *CommentMatcher) StringState(
+	filename, line string, linecnt int, prevToken, currToken, nextToken rune,
+) (state.CommentState, error) {
+	if prevToken != '\\' && currToken == m.stringToken {
+		return state.NonComment, nil
+	}
+
+	return state.String, nil
+}
+
+func isSingleLineOpener(currToken, nextToken rune) bool {
+	return currToken == '#' && nextToken != '['
+}
+
+func isMultiLineOpener(currToken, nextToken rune) bool {
+	return currToken == '#' && nextToken == '['
+}
+
+func isMultiLineCloser(currToken, nextToken rune) bool {
+	return currToken == ']' && nextToken == '#'
+}

--- a/matchers/nim/doc.go
+++ b/matchers/nim/doc.go
@@ -1,0 +1,3 @@
+// Package scripts contains a todo matcher & comments matcher for Nim.
+// Source files contain # for single-line comments, and nestable #[ ]# multiline comments
+package nim

--- a/matchers/nim/todomatcher.go
+++ b/matchers/nim/todomatcher.go
@@ -11,15 +11,19 @@ import (
 // NewTodoMatcher for Nim comments
 func NewTodoMatcher(todos []string) *TodoMatcher {
 	pattern := common.ArrayAsRegexAnyMatchExpression(todos)
-	fmt.Println(pattern)
 
 	// Single line
-	singleLineTodoPattern := regexp.MustCompile(`(?m)^\s*#[^\[].*` + pattern)
-	singleLineValidTodoPattern := regexp.MustCompile(`(?m)^\s*#[^\[] ?` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
+	singleLineTodoPattern := regexp.MustCompile(`^\s*#[^\[].*` + pattern)
+	singleLineValidTodoPattern := regexp.MustCompile(`^\s*#[^\[]` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
 
 	// Multiline line
 	multiLineTodoPattern := regexp.MustCompile(`(?s)^\s*(#\[).*` + pattern)
-	multiLineValidTodoPattern := regexp.MustCompile(`(?s)^\s*(\]#).*` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
+	multiLineValidTodoPattern := regexp.MustCompile(`(?s)^\s*(#\[).*` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
+
+	fmt.Println(singleLineTodoPattern)
+	fmt.Println(singleLineValidTodoPattern)
+	fmt.Println(multiLineTodoPattern)
+	fmt.Println(multiLineValidTodoPattern)
 
 	return &TodoMatcher{
 		singleLineTodoPattern:      singleLineTodoPattern,

--- a/matchers/nim/todomatcher.go
+++ b/matchers/nim/todomatcher.go
@@ -1,7 +1,6 @@
 package nim
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/preslavmihaylov/todocheck/common"
@@ -19,11 +18,6 @@ func NewTodoMatcher(todos []string) *TodoMatcher {
 	// Multiline line
 	multiLineTodoPattern := regexp.MustCompile(`(?s)^\s*(#\[).*` + pattern)
 	multiLineValidTodoPattern := regexp.MustCompile(`(?s)^\s*(#\[).*` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
-
-	fmt.Println(singleLineTodoPattern)
-	fmt.Println(singleLineValidTodoPattern)
-	fmt.Println(multiLineTodoPattern)
-	fmt.Println(multiLineValidTodoPattern)
 
 	return &TodoMatcher{
 		singleLineTodoPattern:      singleLineTodoPattern,

--- a/matchers/nim/todomatcher.go
+++ b/matchers/nim/todomatcher.go
@@ -1,0 +1,64 @@
+package nim
+
+import (
+	"regexp"
+
+	"github.com/preslavmihaylov/todocheck/common"
+	"github.com/preslavmihaylov/todocheck/matchers/errors"
+)
+
+// NewTodoMatcher for python comments
+func NewTodoMatcher(todos []string) *TodoMatcher {
+	pattern := common.ArrayAsRegexAnyMatchExpression(todos)
+
+	// Single line
+	singleLineTodoPattern := regexp.MustCompile(`^\s*#.*` + pattern)
+	singleLineValidTodoPattern := regexp.MustCompile(`^\s*# ` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
+
+	// Multiline line
+	multiLineTodoPattern := regexp.MustCompile(`(?s)^\s*("""|''').*` + pattern)
+	multiLineValidTodoPattern := regexp.MustCompile(`(?s)^\s*("""|''').*` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
+
+	return &TodoMatcher{
+		singleLineTodoPattern:      singleLineTodoPattern,
+		singleLineValidTodoPattern: singleLineValidTodoPattern,
+		multiLineTodoPattern:       multiLineTodoPattern,
+		multiLineValidTodoPattern:  multiLineValidTodoPattern,
+	}
+}
+
+// TodoMatcher for python comments
+type TodoMatcher struct {
+	singleLineTodoPattern      *regexp.Regexp
+	singleLineValidTodoPattern *regexp.Regexp
+	multiLineTodoPattern       *regexp.Regexp
+	multiLineValidTodoPattern  *regexp.Regexp
+}
+
+// IsMatch checks if the current expression matches a python comment
+func (m *TodoMatcher) IsMatch(expr string) bool {
+	return m.singleLineTodoPattern.Match([]byte(expr)) || m.multiLineTodoPattern.Match([]byte(expr))
+}
+
+// IsValid checks if the expression is a valid todo comment
+func (m *TodoMatcher) IsValid(expr string) bool {
+	return m.singleLineValidTodoPattern.Match([]byte(expr)) || m.multiLineValidTodoPattern.Match([]byte(expr))
+}
+
+// ExtractIssueRef from the given expression.
+// If the expression is invalid, an ErrInvalidTODO is returned
+func (m *TodoMatcher) ExtractIssueRef(expr string) (string, error) {
+	if !m.IsValid(expr) {
+		return "", errors.ErrInvalidTODO
+	}
+
+	singleLineRes := m.singleLineValidTodoPattern.FindStringSubmatch(expr)
+	multiLineRes := m.multiLineValidTodoPattern.FindStringSubmatch(expr)
+	if len(singleLineRes) >= 2 {
+		return singleLineRes[1], nil
+	} else if len(multiLineRes) >= 3 {
+		return multiLineRes[2], nil
+	}
+
+	panic("Invariant violated. No issue reference found in valid TODO")
+}

--- a/matchers/nim/todomatcher.go
+++ b/matchers/nim/todomatcher.go
@@ -1,23 +1,25 @@
 package nim
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/preslavmihaylov/todocheck/common"
 	"github.com/preslavmihaylov/todocheck/matchers/errors"
 )
 
-// NewTodoMatcher for python comments
+// NewTodoMatcher for Nim comments
 func NewTodoMatcher(todos []string) *TodoMatcher {
 	pattern := common.ArrayAsRegexAnyMatchExpression(todos)
+	fmt.Println(pattern)
 
 	// Single line
-	singleLineTodoPattern := regexp.MustCompile(`^\s*#.*` + pattern)
-	singleLineValidTodoPattern := regexp.MustCompile(`^\s*# ` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
+	singleLineTodoPattern := regexp.MustCompile(`(?m)^\s*#[^\[].*` + pattern)
+	singleLineValidTodoPattern := regexp.MustCompile(`(?m)^\s*#[^\[] ?` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
 
 	// Multiline line
-	multiLineTodoPattern := regexp.MustCompile(`(?s)^\s*("""|''').*` + pattern)
-	multiLineValidTodoPattern := regexp.MustCompile(`(?s)^\s*("""|''').*` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
+	multiLineTodoPattern := regexp.MustCompile(`(?s)^\s*(#\[).*` + pattern)
+	multiLineValidTodoPattern := regexp.MustCompile(`(?s)^\s*(\]#).*` + pattern + ` (#?[a-zA-Z0-9\-]+):.*`)
 
 	return &TodoMatcher{
 		singleLineTodoPattern:      singleLineTodoPattern,
@@ -27,7 +29,7 @@ func NewTodoMatcher(todos []string) *TodoMatcher {
 	}
 }
 
-// TodoMatcher for python comments
+// TodoMatcher for Nim comments
 type TodoMatcher struct {
 	singleLineTodoPattern      *regexp.Regexp
 	singleLineValidTodoPattern *regexp.Regexp
@@ -35,7 +37,7 @@ type TodoMatcher struct {
 	multiLineValidTodoPattern  *regexp.Regexp
 }
 
-// IsMatch checks if the current expression matches a python comment
+// IsMatch checks if the current expression matches a Nim comment
 func (m *TodoMatcher) IsMatch(expr string) bool {
 	return m.singleLineTodoPattern.Match([]byte(expr)) || m.multiLineTodoPattern.Match([]byte(expr))
 }

--- a/testing/scenariobuilder/builder.go
+++ b/testing/scenariobuilder/builder.go
@@ -211,6 +211,7 @@ func (s *TodocheckScenario) Run() error {
 		return fmt.Errorf("couldn't initialize todocheck config: %w", err)
 	}
 
+	fmt.Println(s.binaryLoc, "--basepath", s.basepath, "--config", s.cfgPath)
 	cmd := exec.Command(s.binaryLoc, "--basepath", s.basepath, "--config", s.cfgPath)
 	if s.versionFlagRequested {
 		cmd.Args = append(cmd.Args, "--version")

--- a/testing/scenariobuilder/builder.go
+++ b/testing/scenariobuilder/builder.go
@@ -211,7 +211,6 @@ func (s *TodocheckScenario) Run() error {
 		return fmt.Errorf("couldn't initialize todocheck config: %w", err)
 	}
 
-	fmt.Println(s.binaryLoc, "--basepath", s.basepath, "--config", s.cfgPath)
 	cmd := exec.Command(s.binaryLoc, "--basepath", s.basepath, "--config", s.cfgPath)
 	if s.versionFlagRequested {
 		cmd.Args = append(cmd.Args, "--version")

--- a/testing/scenarios/nim/main.nim
+++ b/testing/scenarios/nim/main.nim
@@ -4,11 +4,9 @@
 
 when isMainModule:
 # TODO 234: Invalid todo, with a closed issue
-    discard "Hello World" # This is a malformed TODO at the end of a line
+    discard "Hello World" 
 
 #[ TODO 2: Another valid todo ]#
 
     discard "Magic here, magic there!"
-#[ There is an explaination here, but furthermore
 #[ TODO 3: There is also a valid nested todo here! ]#
-]#

--- a/testing/scenarios/nim/main.nim
+++ b/testing/scenarios/nim/main.nim
@@ -9,4 +9,6 @@ when isMainModule:
 #[ TODO 2: Another valid todo ]#
 
     discard "Magic here, magic there!"
+#[
 #[ TODO 3: There is also a valid nested todo here! ]#
+]#

--- a/testing/scenarios/nim/main.nim
+++ b/testing/scenarios/nim/main.nim
@@ -1,0 +1,14 @@
+# This is a single-line malformed TODO
+
+# TODO 1: This is a valid todo comment
+
+when isMainModule:
+    # TODO 234: Invalid todo, with a closed issue
+    discard "Hello World" # This is a malformed TODO at the end of a line
+
+    #[ TODO 2: Another valid todo ]#
+
+    discard "Magic here, magic there!"
+    #[ There is an explaination here, but furthermore
+    #[ TODO 3: There is also a valid nested todo here! ]#
+    ]#

--- a/testing/scenarios/nim/main.nim
+++ b/testing/scenarios/nim/main.nim
@@ -3,12 +3,12 @@
 # TODO 1: This is a valid todo comment
 
 when isMainModule:
-    # TODO 234: Invalid todo, with a closed issue
+# TODO 234: Invalid todo, with a closed issue
     discard "Hello World" # This is a malformed TODO at the end of a line
 
-    #[ TODO 2: Another valid todo ]#
+#[ TODO 2: Another valid todo ]#
 
     discard "Magic here, magic there!"
-    #[ There is an explaination here, but furthermore
-    #[ TODO 3: There is also a valid nested todo here! ]#
-    ]#
+#[ There is an explaination here, but furthermore
+#[ TODO 3: There is also a valid nested todo here! ]#
+]#

--- a/testing/todocheck_test.go
+++ b/testing/todocheck_test.go
@@ -773,6 +773,7 @@ func TestNimTodos(t *testing.T) {
 		WithIssueTracker(issuetracker.Jira).
 		WithIssue("1", issuetracker.StatusOpen).
 		WithIssue("2", issuetracker.StatusOpen).
+		WithIssue("3", issuetracker.StatusClosed).
 		WithIssue("234", issuetracker.StatusClosed).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
@@ -787,17 +788,12 @@ func TestNimTodos(t *testing.T) {
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeIssueClosed).
-				WithLocation("scenarios/nim/main.nim", 7).
-				ExpectLine("# TODO 234: Invalid todo, with a closed issue")).
-		ExpectTodoErr(
-			scenariobuilder.NewTodoErr().
-				WithType(errors.TODOErrTypeIssueClosed).
 				WithLocation("scenarios/nim/main.nim", 9).
 				ExpectLine("#[ TODO 2: Another valid todo ]#")).
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeIssueClosed).
-				WithLocation("scenarios/nim/main.nim", 13).
+				WithLocation("scenarios/nim/main.nim", 12).
 				ExpectLine("#[ TODO 3: There is also a valid nested todo here! ]#")).
 		Run()
 	if err != nil {

--- a/testing/todocheck_test.go
+++ b/testing/todocheck_test.go
@@ -765,6 +765,41 @@ func TestPrintingVersionFlagStopsProgram(t *testing.T) {
 	}
 }
 
+func TestNimTodos(t *testing.T) {
+	err := scenariobuilder.NewScenario().
+		WithBinary("../todocheck").
+		WithBasepath("./scenarios/nim").
+		WithConfig("./test_configs/no_issue_tracker.yaml").
+		WithIssueTracker(issuetracker.Jira).
+		WithIssue("1", issuetracker.StatusOpen).
+		WithIssue("2", issuetracker.StatusOpen).
+		WithIssue("234", issuetracker.StatusClosed).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeMalformed).
+				WithLocation("scenarios/nim/main.nim", 1).
+				ExpectLine("# This is a single-line malformed TODO")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeIssueClosed).
+				WithLocation("scenarios/nim/main.nim", 6).
+				ExpectLine("# TODO 234: Invalid todo, with a closed issue")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeIssueClosed).
+				WithLocation("scenarios/nim/main.nim", 9).
+				ExpectLine("#[ TODO 2: Another valid todo ]#")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeIssueClosed).
+				WithLocation("scenarios/nim/main.nim", 13).
+				ExpectLine("#[ TODO 3: There is also a valid nested todo here! ]#")).
+		Run()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+}
+
 func TestVueTodos(t *testing.T) {
 	err := scenariobuilder.NewScenario().
 		WithBinary("../todocheck").

--- a/testing/todocheck_test.go
+++ b/testing/todocheck_test.go
@@ -787,6 +787,11 @@ func TestNimTodos(t *testing.T) {
 		ExpectTodoErr(
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeIssueClosed).
+				WithLocation("scenarios/nim/main.nim", 7).
+				ExpectLine("# TODO 234: Invalid todo, with a closed issue")).
+		ExpectTodoErr(
+			scenariobuilder.NewTodoErr().
+				WithType(errors.TODOErrTypeIssueClosed).
 				WithLocation("scenarios/nim/main.nim", 9).
 				ExpectLine("#[ TODO 2: Another valid todo ]#")).
 		ExpectTodoErr(

--- a/testing/todocheck_test.go
+++ b/testing/todocheck_test.go
@@ -772,7 +772,7 @@ func TestNimTodos(t *testing.T) {
 		WithConfig("./test_configs/no_issue_tracker.yaml").
 		WithIssueTracker(issuetracker.Jira).
 		WithIssue("1", issuetracker.StatusOpen).
-		WithIssue("2", issuetracker.StatusOpen).
+		WithIssue("2", issuetracker.StatusClosed).
 		WithIssue("3", issuetracker.StatusClosed).
 		WithIssue("234", issuetracker.StatusClosed).
 		ExpectTodoErr(
@@ -794,7 +794,9 @@ func TestNimTodos(t *testing.T) {
 			scenariobuilder.NewTodoErr().
 				WithType(errors.TODOErrTypeIssueClosed).
 				WithLocation("scenarios/nim/main.nim", 12).
-				ExpectLine("#[ TODO 3: There is also a valid nested todo here! ]#")).
+				ExpectLine("#[").
+				ExpectLine("#[ TODO 3: There is also a valid nested todo here! ]#").
+				ExpectLine("]#")).
 		Run()
 	if err != nil {
 		t.Errorf("%s", err)


### PR DESCRIPTION
Closes #157.
The implementation is based on the standard nested comment variant, but substitutes `/*` and `*/` for `#[` and `]#` respectively. 