### PR TITLE
[WIP] Fix JSON output for closed-issue type comments not including TODO message

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -47,11 +47,23 @@ func (c *Checker) Check(
 		return nil, fmt.Errorf("couldn't fetch task status: %w", err)
 	}
 
+	// Extract message by slicing off the necessary tokens ("TODO {taskId}: ")
+	colonPos := func() int {
+		for i := range comment {
+			if comment[i] == ':' {
+				return i
+			}
+		}
+		// Cannot happen as TODO format guarantees presence of colon
+		return -1
+	}()
+	message := comment[colonPos+2:]
+
 	switch status {
 	case taskstatus.Closed:
-		return checkererrors.IssueClosedErr(filename, lines, linecnt, taskID), nil
+		return checkererrors.IssueClosedErr(filename, lines, linecnt, taskID, message), nil
 	case taskstatus.NonExistent:
-		return checkererrors.IssueNonExistentErr(filename, lines, linecnt, taskID), nil
+		return checkererrors.IssueNonExistentErr(filename, lines, linecnt, taskID, message), nil
 	}
 
 	return nil, nil

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -3,6 +3,7 @@ package checker
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	checkererrors "github.com/preslavmihaylov/todocheck/checker/errors"
 	"github.com/preslavmihaylov/todocheck/fetcher"
@@ -47,17 +48,7 @@ func (c *Checker) Check(
 		return nil, fmt.Errorf("couldn't fetch task status: %w", err)
 	}
 
-	// Extract message by slicing off the necessary tokens ("TODO {taskId}: ")
-	colonPos := func() int {
-		for i := range comment {
-			if comment[i] == ':' {
-				return i
-			}
-		}
-		// Cannot happen as TODO format guarantees presence of colon
-		return -1
-	}()
-	message := comment[colonPos+2:]
+	message := strings.Join(strings.Split(comment, "\n"), "")
 
 	switch status {
 	case taskstatus.Closed:

--- a/checker/errors/errors.go
+++ b/checker/errors/errors.go
@@ -24,6 +24,7 @@ type TODO struct {
 	lines    []string
 	linecnt  int
 	metadata map[string]string
+	message  string
 }
 
 // ToJSON converts the todo error into json format
@@ -38,12 +39,8 @@ func (err *TODO) ToJSON() ([]byte, error) {
 		Type:     string(err.errType),
 		Filename: err.filename,
 		Line:     err.linecnt,
-		Message:  "",
+		Message:  err.message,
 		Metadata: err.metadata,
-	}
-
-	if err.errType == TODOErrTypeMalformed {
-		res.Message = "TODO should match pattern - TODO {task_id}:"
 	}
 
 	return json.Marshal(res)
@@ -71,11 +68,12 @@ func MalformedTODOErr(filename string, lines []string, linecnt int) *TODO {
 		lines:    lines,
 		linecnt:  linecnt,
 		metadata: make(map[string]string),
+		message:  "TODO should match pattern - TODO {task_id}:",
 	}
 }
 
 // IssueClosedErr when referenced todo issue is closed
-func IssueClosedErr(filename string, lines []string, linecnt int, issueID string) *TODO {
+func IssueClosedErr(filename string, lines []string, linecnt int, issueID string, message string) *TODO {
 	return &TODO{
 		errType:  TODOErrTypeIssueClosed,
 		filename: filename,
@@ -84,11 +82,12 @@ func IssueClosedErr(filename string, lines []string, linecnt int, issueID string
 		metadata: map[string]string{
 			"issueID": issueID,
 		},
+		message: message,
 	}
 }
 
 // IssueNonExistentErr when referenced todo issue doesn't exist
-func IssueNonExistentErr(filename string, lines []string, linecnt int, issueID string) *TODO {
+func IssueNonExistentErr(filename string, lines []string, linecnt int, issueID string, message string) *TODO {
 	return &TODO{
 		errType:  TODOErrTypeNonExistentIssue,
 		filename: filename,
@@ -97,6 +96,7 @@ func IssueNonExistentErr(filename string, lines []string, linecnt int, issueID s
 		metadata: map[string]string{
 			"issueID": issueID,
 		},
+		message: message,
 	}
 }
 

--- a/testing/scenariobuilder/todoerr_scenario.go
+++ b/testing/scenariobuilder/todoerr_scenario.go
@@ -12,6 +12,7 @@ type TodoErrScenario struct {
 	sourceFile    string
 	sourceLineNum int
 	contents      []string
+	message       string
 	metadata      map[string]string
 }
 
@@ -66,6 +67,12 @@ func (s *TodoErrScenario) WithJSONMetadataEntry(key string, value string) *TodoE
 	return s
 }
 
+// WithMessage stores the expected extracted message.
+func (s *TodoErrScenario) WithMessage(message string) *TodoErrScenario {
+	s.message = message
+	return s
+}
+
 func (s *TodoErrScenario) String() string {
 	str := fmt.Sprintf("ERROR: %s", s.errType)
 	for i := 0; i < len(s.contents); i++ {
@@ -113,7 +120,7 @@ func (s *TodoErrScenario) ToTodoErrForJSON() *TodoErrForJSON {
 		Type:     string(s.errType),
 		Filename: s.sourceFile,
 		Line:     s.sourceLineNum,
-		Message:  "",
+		Message:  s.message,
 		Metadata: s.metadata,
 	}
 


### PR DESCRIPTION
Reopened the PR due to duplicate commits in the old PR.

The output for single line comments currently looks good:
```
{
  "type": "Issue doesn't exist",
  "filename": "testing/scenarios/custom_todos/groovy/main.groovy",
  "line": 21,
  "message": "// TODO 3: The issue is non-existent",
  "metadata": {
    "issueID": "3"
  }
},
```

but the output for multiline looks a little odd.
```
{
  "type": "Issue doesn't exist",
  "filename": "testing/scenarios/custom_todos/groovy/main.groovy",
  "line": 56,
  "message": "/**\u0000* TODO 2: Invalid todo as issue is closed\u0000*/",
  "metadata": {
    "issueID": "2"
  }
},
```