### PR TITLE
fix linting issues after #167

### DIFF
--- a/matchers/caseinsensitive/todomatcher.go
+++ b/matchers/caseinsensitive/todomatcher.go
@@ -1,4 +1,4 @@
-package case_insensitive
+package caseinsensitive
 
 import (
 	"regexp"

--- a/traverser/todoerrs/todoerrs.go
+++ b/traverser/todoerrs/todoerrs.go
@@ -7,7 +7,7 @@ import (
 	"github.com/preslavmihaylov/todocheck/checker/errors"
 	"github.com/preslavmihaylov/todocheck/fetcher"
 	"github.com/preslavmihaylov/todocheck/matchers"
-	"github.com/preslavmihaylov/todocheck/matchers/case_insensitive"
+	"github.com/preslavmihaylov/todocheck/matchers/caseinsensitive"
 	"github.com/preslavmihaylov/todocheck/matchers/state"
 	"github.com/preslavmihaylov/todocheck/traverser/comments"
 )
@@ -31,7 +31,7 @@ func commentsCallback(chk *checker.Checker, customTodos []string, matchCaseInsen
 	return func(comment, filepath string, lines []string, linecnt int) error {
 		matcher := matchers.TodoMatcherForFile(filepath, customTodos)
 		if matchCaseInsensitive {
-			matcher = case_insensitive.NewTodoMatcher(matcher)
+			matcher = caseinsensitive.NewTodoMatcher(matcher)
 		}
 
 		todoErr, err := chk.Check(matcher, comment, filepath, lines, linecnt)


### PR DESCRIPTION
There was a linting issue introduced after merging #167. This PR addresses that.

The issue is that package names should not use underscores.