### PR TITLE
Fix url validation regex

### DIFF
--- a/config/issuetracker.go
+++ b/config/issuetracker.go
@@ -40,11 +40,11 @@ var validIssueTrackers = []IssueTracker{
 }
 
 var originPatterns = map[IssueTracker]*regexp.Regexp{
-	IssueTrackerJira:     regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9]+)+(:[0-9]+)?$`),
+	IssueTrackerJira:     regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)+(:[0-9]+)?$`),
 	IssueTrackerGithub:   regexp.MustCompile(`^(https?://)?(www\.)?github\.com/[\w-]+/[\w-]+`),
-	IssueTrackerGitlab:   regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9]+)+(:[0-9]+)?/[\w-]+/[\w-]+$`),
+	IssueTrackerGitlab:   regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)+(:[0-9]+)?/[\w-]+/[\w-]+$`),
 	IssueTrackerPivotal:  regexp.MustCompile(`^(https?://)?(www\.)?pivotaltracker\.com/n/projects/[0-9]+`),
-	IssueTrackerRedmine:  regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9]+)+(:[0-9]+)?$`),
+	IssueTrackerRedmine:  regexp.MustCompile(`^(https?://)?[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)+(:[0-9]+)?$`),
 	IssueTrackerYoutrack: regexp.MustCompile(`^(https?://)?(www\.)?[0-9A-z-]{2,}\/?.*$`),
 	IssueTrackerAzure:    regexp.MustCompile(`^(https?://)?(www\.)?dev\.azure\.com/([a-zA-Z0-9]+)+\/([a-zA-Z0-9]+)+.*$`),
 }


### PR DESCRIPTION
Fix a bug where toplevel domains containing a "-" would falsely be
flagged as invalid