### PR TITLE
setup docker build & package registry

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,53 @@
+name: docker-build
+
+on:
+  push:
+    branches:
+      - "master*"
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker-build:
+    name: Build and deploy container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+      - name: Export git tag
+        uses: tenhaus/get-release-or-tag@v2
+        id: tag
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # branch event
+            type=ref,event=branch
+            # tag event
+            type=ref,event=tag
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: TODOCHECK_VERSION=${{ steps.tag.outputs.tag }}
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.18.5-alpine3.16 AS build
+ARG TODOCHECK_VERSION=custom_version
+
+RUN apk add --no-cache \
+    make
+ADD . /usr/src/todocheck
+WORKDIR /usr/src/todocheck 
+
+# Build
+RUN go build -ldflags "-X main.version=$TODOCHECK_VERSION"
+RUN cp todocheck /usr/local/bin/todocheck
+
+FROM alpine:3.16
+COPY --from=build /usr/local/bin/todocheck /usr/local/bin/todocheck
+ENTRYPOINT ["/usr/local/bin/todocheck"]
+
+

--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Optionally verify the `sha256` checksum:
 Place the binary in a folder, shined upon by your `$PATH`.
  * For macos & linux, that's typically `/usr/local/bin/`
 
+## Using a Container
+Alternatively to installing the todocheck binary on your system you may use a prebuilt container image from the GitHub container registry, e.g.:
+
+```bash
+docker run -it -v /path/to/project:/project -e TODOCHECK_AUTH_TOKEN=your_token ghcr.io/preslavmihaylov/todocheck --basepath /project
+```
+
+For a complete list of container tags visit the [Packages section](https://github.com/preslavmihaylov/todocheck/pkgs/container/todocheck) on the GitHub project page.
+For a complete list of `docker run` options visit the [Docker documentation](https://docs.docker.com/engine/reference/commandline/run/).
+
 # Quickstart
 First, you need to configure `todocheck`'s integration with your issue tracker.
 This is done by creating a `.todocheck.yaml` file in the root of your project.


### PR DESCRIPTION
Related to https://github.com/preslavmihaylov/todocheck/issues/83

Kudos goes to @Jasper-Ben who drove this via https://github.com/preslavmihaylov/todocheck/pull/192

This PR sets up a `Dockerfile`, which builds `todocheck` as a docker image & publishes it to the github container registry on push to master + new releases.