### PR TITLE
Add back azureboards private config

### DIFF
--- a/testing/test_configs/integrations/azureboards_private.yaml
+++ b/testing/test_configs/integrations/azureboards_private.yaml
@@ -1,0 +1,4 @@
+origin: https://dev.azure.com/todoerruser/private_todocheck
+issue_tracker: AZURE
+auth:
+  type: apitoken


### PR DESCRIPTION
Adding this back as it's used in one of the tests for checking the api token acquisition instructions are correct, which is separate from the integration itself.