### PR TITLE
Add .ccagent/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tmp/
 todocheck
 testing/authtokens.yaml
+.ccagent/


### PR DESCRIPTION
## Summary

Added `.ccagent/` directory to gitignore to prevent tracking of ccagent-related temporary files and configurations.

## Changes

- Updated `.gitignore` to exclude `.ccagent/` directory from version control

---
Generated with [Claude Control](https://claudecontrol.com) from this [slack thread](https://sideprojects-mw61570.slack.com/archives/C096LGC5PBN/p1753899966419759)