### PR TITLE
feat(build): add darwin arm64 builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 tmp/
+binaries-custom_*/
 todocheck
 testing/authtokens.yaml
+.DS_Store

--- a/release.sh
+++ b/release.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR=$1
 VERSION=$2
 
-if [ -z "$DIR" ] || [ -z "$VERSION" ]; then 
+if [ -z "$DIR" ] || [ -z "$VERSION" ]; then
     echo "Usage: release.sh <target-dir> <version>"
     exit 1
 fi
@@ -24,5 +24,6 @@ function create_build {
 mkdir -p $DIR
 create_build windows amd64 x86_64.exe
 create_build darwin amd64 x86_64
+create_build darwin arm64
 create_build linux amd64 x86_64
 create_build linux arm64


### PR DESCRIPTION
Hi 👋

I noticed there were no builds for m series macs, so I have added that to the builds in the release script.

I'm relly new to go, but I tested the enw ARM build locally against the tests in the repo and it worked fine.

Please let me know if there was anything I missed.

Thank you